### PR TITLE
Refresh confidential client every 3 days, adjust telemetry settings.

### DIFF
--- a/SafeExchange.Functions/host.json
+++ b/SafeExchange.Functions/host.json
@@ -3,6 +3,8 @@
   "logging": {
     "logLevel": {
       "default": "Information",
+      "Azure.Core": "Warning",
+      "Microsoft.EntityFrameworkCore": "Warning",
       "SafeExchange.Core": "Information",
       "System.Net.Http.HttpClient": "Warning"
     },


### PR DESCRIPTION
1. Confidential client should be recreated periodically (every 3 days), because client secret or certificate can be changed, and for premium azure functions plan an instance can live for a long time, therefore if a client is created once, it never gets new settings unless function is restarted.
2. Adjust telemetry settings, so that storage queue http calls are not 'contaminating' telemetry.