### PR TITLE
chore(deps): fix Kiota High-severity vuln + safe NuGet upgrades

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,39 +1,44 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.51.1" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.19.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.9.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="Azure.Core" Version="1.57.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.10.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.26.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.51.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.52.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.4" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Graph" Version="5.103.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.16.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="8.16.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <!-- Security pin (transitive via Microsoft.Graph): GHSA-7j59-v9qr-6fq9 /
+         CVE-2026-44503 (High) is fixed in Microsoft.Kiota.Abstractions 1.22.0.
+         Graph 5.103.0 pulls 1.21.1; pin it forward until Graph itself moves. -->
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Remediates the **High-severity Kiota vulnerability** and applies safe minor/patch NuGet upgrades. Separate from the telemetry hotfix (already on `main`).

## Security fix
- **`Microsoft.Kiota.Abstractions` 1.21.1 → 1.22.0** (transitive via `Microsoft.Graph`) — fixes **GHSA-7j59-v9qr-6fq9 / CVE-2026-44503** (High; RedirectHandler leaks `Cookie`/`Proxy-Authorization` headers on cross-host redirect). Enabled `CentralPackageTransitivePinningEnabled` so the pin takes effect.

## Safe upgrades (minor/patch)
- Azure: Core 1.51.1→1.57.0, Identity 1.19.0→1.21.0, KeyVault Keys 4.9.0→4.10.0 / Secrets 4.9.0→4.11.0, Storage Blobs 12.27.0→12.28.0 / Queues 12.25.0→12.26.0, Config.Secrets 1.5.0→1.5.1
- EF Core + Microsoft.Extensions.* 10.0.5→10.0.8
- Microsoft.IdentityModel.* 8.16.0→8.18.0
- Functions.Worker(.Core) 2.51.0→2.52.0
- Tests: NET.Test.Sdk 18.3.0→18.6.0, NUnit 4.5.1→4.6.1, coverlet 8.0.1→10.0.1

## Held back (breaking majors — separate change)
- `Microsoft.Graph` 5→6, `Microsoft.ApplicationInsights` 2→3 (+ `Logging.ApplicationInsights`). These need API/code changes + testing; deliberately excluded to keep this PR low-risk (especially AI, right after the telemetry hotfix).

## Verification
- Clean restore (no NU1605 downgrade conflicts)
- `dotnet build -c Release`: **0 errors**
- `dotnet list package --vulnerable`: **no vulnerable packages**
- `dotnet test`: **354/360 pass** against the Cosmos emulator
  - The 6 failures (`ApplicationOwnerInvariantTests`, `ArgumentNullException (dbContext)`) are **pre-existing on `main`** (verified — identical failure without these changes) and are a test-helper bug unrelated to dependencies.

## Follow-ups
- Fix the 6 pre-existing `ApplicationOwnerInvariantTests` failures (test helper passes `null` dbContext).
- Evaluate the breaking majors (Graph 6, ApplicationInsights 3) separately.