### PR TITLE
fix(telemetry): make telemetry-id rotation best-effort so it never 500s a request

### DIFF
--- a/SafeExchange.Core/Middleware/TokenMiddlewareCore.cs
+++ b/SafeExchange.Core/Middleware/TokenMiddlewareCore.cs
@@ -15,6 +15,7 @@ namespace SafeExchange.Core.Middleware
     using SafeExchange.Core.Telemetry;
     using SafeExchange.Core.Utilities;
     using System;
+    using System.Linq;
     using System.Net;
     using System.Security.Claims;
     using System.Threading.Tasks;
@@ -110,7 +111,23 @@ namespace SafeExchange.Core.Middleware
                     });
                 }
 
-                await this.dbContext.SaveChangesAsync();
+                // Recording the rotated telemetry id is best-effort bookkeeping: when the
+                // web client fires several requests in parallel at the rotation boundary,
+                // they race to insert the same retired-id map entry and all but one get a
+                // Cosmos 409 Conflict. That must never fail the user's actual request, so
+                // the conflict (and any other failure) is swallowed here.
+                var saveResult = await DbUtils.TrySaveBestEffortAsync(
+                    () => this.dbContext.SaveChangesAsync(),
+                    this.log,
+                    "persisting rotated telemetry id");
+
+                if (saveResult != BestEffortSaveResult.Saved)
+                {
+                    // The request-scoped DbContext is shared with the function handler, so
+                    // drop the un-persisted map entry; otherwise a later SaveChanges in the
+                    // handler would re-attempt the conflicting insert and surface the 500.
+                    this.DetachTrackedTelemetryMapEntries();
+                }
             }
 
             // Stamp the telemetry id onto this request's frame so logs emitted within
@@ -123,6 +140,14 @@ namespace SafeExchange.Core.Middleware
             request.FunctionContext.Items[DefaultAuthenticationMiddleware.InvocationContextUserIdKey] = user.Id;
             await this.UpdateGroupsAsync(user, request, principal);
             return result;
+        }
+
+        private void DetachTrackedTelemetryMapEntries()
+        {
+            foreach (var entry in this.dbContext.ChangeTracker.Entries<TelemetryIdMapEntry>().ToList())
+            {
+                entry.State = EntityState.Detached;
+            }
         }
 
         private async Task<User?> GetOrCreateUserAsync(ClaimsPrincipal principal)

--- a/SafeExchange.Core/Utilities/BestEffortSaveResult.cs
+++ b/SafeExchange.Core/Utilities/BestEffortSaveResult.cs
@@ -1,0 +1,22 @@
+/// <summary>
+/// BestEffortSaveResult
+/// </summary>
+
+namespace SafeExchange.Core.Utilities
+{
+    /// <summary>Outcome of a best-effort, non-fatal persistence attempt
+    /// (see <see cref="DbUtils.TrySaveBestEffortAsync"/>).</summary>
+    public enum BestEffortSaveResult
+    {
+        /// <summary>The write was persisted.</summary>
+        Saved,
+
+        /// <summary>A Cosmos 409 Conflict was swallowed — a concurrent request had
+        /// already written the same item, so the desired end state already holds.</summary>
+        Conflict,
+
+        /// <summary>An unexpected failure was logged and swallowed; the caller's
+        /// primary operation was allowed to continue.</summary>
+        Failed,
+    }
+}

--- a/SafeExchange.Core/Utilities/DbUtils.cs
+++ b/SafeExchange.Core/Utilities/DbUtils.cs
@@ -23,5 +23,32 @@ namespace SafeExchange.Core.Utilities
                 return await getAsync();
             }
         }
+
+        /// <summary>
+        /// Runs a non-critical, side-effect persistence (e.g. telemetry bookkeeping)
+        /// that must never fail the caller's primary operation. A Cosmos 409 Conflict
+        /// is swallowed as success-by-idempotency (a concurrent request already wrote
+        /// the same item); any other failure is logged and swallowed.
+        /// </summary>
+        public static async Task<BestEffortSaveResult> TrySaveBestEffortAsync(Func<Task> saveAsync, ILogger log, string description)
+        {
+            try
+            {
+                await saveAsync();
+                return BestEffortSaveResult.Saved;
+            }
+            catch (DbUpdateException dbUpdateException)
+                when (dbUpdateException.InnerException is CosmosException cosmosException &&
+                      cosmosException.StatusCode == HttpStatusCode.Conflict)
+            {
+                log.LogInformation("Conflict while {Description}; already written by a concurrent request.", description);
+                return BestEffortSaveResult.Conflict;
+            }
+            catch (Exception exception)
+            {
+                log.LogWarning(exception, "Best-effort operation '{Description}' failed; continuing without failing the request.", description);
+                return BestEffortSaveResult.Failed;
+            }
+        }
     }
 }

--- a/SafeExchange.Tests/Tests/DbUtilsBestEffortSaveTests.cs
+++ b/SafeExchange.Tests/Tests/DbUtilsBestEffortSaveTests.cs
@@ -1,0 +1,80 @@
+namespace SafeExchange.Tests
+{
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging.Abstractions;
+    using NUnit.Framework;
+    using SafeExchange.Core.Utilities;
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Covers <see cref="DbUtils.TrySaveBestEffortAsync"/>, the conflict-swallowing,
+    /// best-effort persistence used for non-critical side-effect writes (e.g. the
+    /// rotating telemetry id bookkeeping in the auth middleware) which must never
+    /// fail the caller's primary request.
+    /// </summary>
+    [TestFixture]
+    public class DbUtilsBestEffortSaveTests
+    {
+        [Test]
+        public async Task TrySaveBestEffortAsync_SaveSucceeds_ReturnsSaved()
+        {
+            var result = await DbUtils.TrySaveBestEffortAsync(
+                () => Task.CompletedTask,
+                NullLogger.Instance,
+                "test save");
+
+            Assert.That(result, Is.EqualTo(BestEffortSaveResult.Saved));
+        }
+
+        [Test]
+        public async Task TrySaveBestEffortAsync_CosmosConflict_IsSwallowedAndReportsConflict()
+        {
+            // Reproduces the production race: two concurrent requests both insert the
+            // same retired telemetry id, the loser gets a Cosmos 409 wrapped in a
+            // DbUpdateException. It must NOT propagate (the row already exists).
+            var conflict = new DbUpdateException(
+                "Conflicts were detected for item.",
+                new CosmosException("Resource with specified id or name already exists.", HttpStatusCode.Conflict, 0, "activity-id", 0));
+
+            var result = await DbUtils.TrySaveBestEffortAsync(
+                () => throw conflict,
+                NullLogger.Instance,
+                "persisting rotated telemetry id");
+
+            Assert.That(result, Is.EqualTo(BestEffortSaveResult.Conflict));
+        }
+
+        [Test]
+        public async Task TrySaveBestEffortAsync_UnexpectedException_IsSwallowedAndReportsFailed()
+        {
+            // Best-effort: any other failure persisting telemetry bookkeeping must be
+            // logged and swallowed, never surfaced as a 500 to the user's real request.
+            var result = await DbUtils.TrySaveBestEffortAsync(
+                () => throw new InvalidOperationException("transient db failure"),
+                NullLogger.Instance,
+                "persisting rotated telemetry id");
+
+            Assert.That(result, Is.EqualTo(BestEffortSaveResult.Failed));
+        }
+
+        [Test]
+        public async Task TrySaveBestEffortAsync_NonConflictDbUpdateException_IsSwallowedAndReportsFailed()
+        {
+            // A DbUpdateException that is not a 409 (e.g. throttling/unavailable) is
+            // still non-fatal for telemetry bookkeeping and must be swallowed.
+            var nonConflict = new DbUpdateException(
+                "Service unavailable.",
+                new CosmosException("Service is currently unavailable.", HttpStatusCode.ServiceUnavailable, 0, "activity-id", 0));
+
+            var result = await DbUtils.TrySaveBestEffortAsync(
+                () => throw nonConflict,
+                NullLogger.Instance,
+                "persisting rotated telemetry id");
+
+            Assert.That(result, Is.EqualTo(BestEffortSaveResult.Failed));
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/UserTests.cs
+++ b/SafeExchange.Tests/Tests/UserTests.cs
@@ -221,6 +221,58 @@ namespace SafeExchange.Tests
         }
 
         [Test]
+        public async Task RotationRace_DuplicateRetiredIdMapEntry_IsSwallowed_RequestSucceeds()
+        {
+            // [GIVEN] An existing user whose telemetry id has already expired, so the
+            // next authenticated request rotates it and records the retired id.
+            const string retiredId = "retiredtelemetryid00000000racetest";
+            var existingUser = new SafeExchange.Core.Model.User(
+                "First User",
+                "00000000-0000-0000-0000-000000000001",
+                "00000000-0000-0000-0000-000000000001",
+                "first@test.test", "first@test.test")
+            {
+                TelemetryId = retiredId,
+                TelemetryIdIssuedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                TelemetryIdExpiresAt = new DateTime(2020, 1, 8, 0, 0, 0, DateTimeKind.Utc),
+            };
+            await this.dbContext.Users.AddAsync(existingUser);
+
+            // [GIVEN] A concurrent request (the race "winner") has already written the
+            // TelemetryIdMap entry for that retired id.
+            await this.dbContext.Set<TelemetryIdMapEntry>().AddAsync(new TelemetryIdMapEntry
+            {
+                id = retiredId,
+                UserId = existingUser.Id,
+                ValidFromUtc = existingUser.TelemetryIdIssuedAt,
+                ValidToUtc = existingUser.TelemetryIdExpiresAt,
+            });
+            await this.dbContext.SaveChangesAsync();
+
+            // A second, independent request runs on its own DbContext (as it would in a
+            // separate function invocation), so the duplicate insert reaches Cosmos and
+            // comes back as a 409 Conflict rather than being caught by local tracking.
+            var racingMiddleware = new TokenMiddlewareCore(
+                this.testConfiguration, new SafeExchangeDbContext(this.dbContextOptions), this.tokenHelper,
+                this.graphDataProvider, new TelemetryIdRotator(), this.middlewareLogger);
+
+            var claimsPrincipal = new ClaimsPrincipal(this.firstIdentity);
+            var request = TestFactory.CreateHttpRequestData("get");
+
+            // [WHEN] The racing request runs the auth middleware (which rotates and
+            // re-inserts the same retired-id entry, hitting the Cosmos 409).
+            var result = await racingMiddleware.RunAsync(request, claimsPrincipal);
+
+            // [THEN] The 409 is swallowed — the request is allowed to proceed (no 500) ...
+            Assert.That(result.shouldReturn, Is.False);
+
+            // ... and still carries a freshly-rotated telemetry id distinct from the retired one.
+            var stampedTelemetryId = request.FunctionContext.GetTelemetryId();
+            Assert.That(stampedTelemetryId, Is.Not.Empty);
+            Assert.That(stampedTelemetryId, Is.Not.EqualTo(retiredId));
+        }
+
+        [Test]
         public async Task SimultaneousUserCalls_WithGroups()
         {
             var builder = new ConfigurationBuilder().AddUserSecrets<UserTests>();


### PR DESCRIPTION
## Summary

Fixes intermittent **HTTP 500s in the Blazor PWA web client** caused by the rotating telemetry-id feature racing on its Cosmos insert.

## Root cause (from prod App Insights, `safeexchange-backend-insights`)

On **2026-06-18 14:58:40 UTC**, two requests 500'd at the same instant with identical ~3088 ms duration:

| Endpoint | Operation |
|---|---|
| `/api/v2/telemetry/config` | `SafeExchange-TelemetryConfig` |
| `/api/v2/secret-list` | `SafeExchange-ListSecretMeta` |

Both failed with the same exception — a **Cosmos `409 Conflict`** on a `Create` into the `TelemetryIdMap` collection (`id` = retired telemetry id `a6de…`), surfaced as `Microsoft.EntityFrameworkCore.DbUpdateException`.

`TokenMiddlewareCore.RunAsync` runs the telemetry-id rotation on **every authenticated request** (that's why a read like `secret-list` writes to the DB). The PWA fires `telemetry/config` **and** `secret-list` **in parallel** on page load. At the rotation boundary both read the same user, both rotate, and both try to insert the **same** retired-id `TelemetryIdMapEntry` → one wins, the loser gets a 409 → unhandled → **500**.

Rotation is calendar-aligned (`TelemetryIdRotator.NextWeekBoundaryUtc` → Monday 00:00 UTC), so this is **recurring/reproducible**: the first concurrent burst per user after each boundary loses all-but-one request.

This is a known race class in this codebase — the `User` insert two methods below already guards it via `DbUtils.TryAddOrGetEntityAsync` (swallow Cosmos 409); the same protection was used for user groups. The `TelemetryIdMapEntry` insert simply never got that guard.

## The fix

- **#1 Swallow the conflict.** New `DbUtils.TrySaveBestEffortAsync` swallows a Cosmos 409 (the row already exists, written by a concurrent request) — mirroring the existing `TryAddOrGetEntityAsync` conflict predicate.
- **#2 Best-effort bookkeeping.** Any *other* failure persisting the telemetry id is logged (warning) and swallowed, so telemetry plumbing can **never** fail a user's real request.
- **Change-tracker hygiene.** The request-scoped `SafeExchangeDbContext` is shared with the function handler, so on a swallowed failure the un-persisted `TelemetryIdMapEntry` is **detached** — otherwise a write handler's later `SaveChanges` would re-attempt the conflicting insert and re-surface the 500. The `User` rotation stays tracked so a later save still persists it.

## Tests

- **4 unit tests** (`DbUtilsBestEffortSaveTests`) cover saved / Cosmos-409-conflict / unexpected-exception / non-conflict-`DbUpdateException` paths (verified red→green).
- **1 end-to-end regression test** against the Cosmos emulator (`UserTests.RotationRace_DuplicateRetiredIdMapEntry_IsSwallowed_RequestSucceeds`): seeds an expired-telemetry-id user + the retired-id map entry, then drives the real auth middleware on a separate `DbContext` so the duplicate insert reaches Cosmos as a genuine 409. **Verified red→green** — fails with the pre-fix `await SaveChangesAsync()`, passes with the fix.
- ✅ **Full suite green against the Cosmos emulator (Docker vNext-preview): 418/418 passed.** Production code builds clean.

## Risk

Low and localized to the telemetry-id rotation path. No public API or schema change. Behavior change: telemetry-id bookkeeping is now non-fatal instead of able to 500 a request.
