### PR TITLE
feat(s2s): cross-tenant S2S app tokens via configured tenant allowlist + application search

### DIFF
--- a/SafeExchange.Core/Configuration/AuthenticationConfiguration.cs
+++ b/SafeExchange.Core/Configuration/AuthenticationConfiguration.cs
@@ -26,6 +26,16 @@ namespace SafeExchange.Core.Configuration
         public string ValidIssuers { get; set; } = string.Empty;
 
         /// <summary>
+        /// Optional JSON array of tenants from which APP-ONLY (S2S / client-credentials)
+        /// tokens are accepted, IN ADDITION to the configured home tenant. Each entry is
+        /// <c>{ "tenantId": "&lt;guid&gt;", "displayName": "&lt;label&gt;" }</c>. Empty /
+        /// missing ⇒ the feature is off and token validation is byte-for-byte unchanged.
+        /// User (delegated) tokens are unaffected — they are still accepted only from the
+        /// configured home tenant. Parsed by <see cref="S2SAllowedTenant.ParseList"/>.
+        /// </summary>
+        public string S2SAllowedTenants { get; set; } = string.Empty;
+
+        /// <summary>
         /// Comma-separated list of claim types, in order of preference, that
         /// <see cref="TokenHelper.GetUpn"/> will try when resolving the caller's
         /// UPN. The first non-empty claim wins.

--- a/SafeExchange.Core/Configuration/S2SAllowedTenant.cs
+++ b/SafeExchange.Core/Configuration/S2SAllowedTenant.cs
@@ -1,0 +1,117 @@
+/// <summary>
+/// S2SAllowedTenant — a single entry in the Authentication:S2SAllowedTenants
+/// allowlist, plus the parser/lookup helpers. Parsing FAILS CLOSED: any malformed
+/// or missing configuration yields an empty list (no S2S tenants trusted) rather
+/// than throwing — a bad config value must not widen trust, and must not take the
+/// whole Functions app down on startup.
+/// </summary>
+
+namespace SafeExchange.Core.Configuration
+{
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
+
+    public sealed class S2SAllowedTenant
+    {
+        public S2SAllowedTenant(string tenantId, string displayName)
+        {
+            this.TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+            this.DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+        }
+
+        /// <summary>Entra tenant id (GUID) whose app-only tokens are accepted.</summary>
+        public string TenantId { get; }
+
+        /// <summary>Friendly label shown in the registration tenant picker.</summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Parses the JSON-array config value into a validated, de-duplicated list.
+        /// Non-GUID tenant ids and non-object entries are skipped; a missing
+        /// displayName defaults to the tenant id; duplicate tenant ids keep the
+        /// first occurrence. Returns an empty list for null/empty/malformed input.
+        /// </summary>
+        public static IReadOnlyList<S2SAllowedTenant> ParseList(string? configValue, ILogger? log = null)
+        {
+            var result = new List<S2SAllowedTenant>();
+            if (string.IsNullOrWhiteSpace(configValue))
+            {
+                return result;
+            }
+
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(configValue);
+            }
+            catch (JsonException ex)
+            {
+                log?.LogError(ex, "Authentication:S2SAllowedTenants is not valid JSON; treating as empty (no S2S tenants trusted).");
+                return result;
+            }
+
+            using (document)
+            {
+                if (document.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    log?.LogError("Authentication:S2SAllowedTenants must be a JSON array; treating as empty (no S2S tenants trusted).");
+                    return result;
+                }
+
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var element in document.RootElement.EnumerateArray())
+                {
+                    if (element.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    var tenantId = GetString(element, "tenantId")?.Trim();
+                    if (string.IsNullOrWhiteSpace(tenantId) || !Guid.TryParseExact(tenantId, "D", out _))
+                    {
+                        log?.LogWarning("Skipping S2S allowed tenant entry with missing or non-GUID tenantId.");
+                        continue;
+                    }
+
+                    if (!seen.Add(tenantId))
+                    {
+                        continue;
+                    }
+
+                    var displayName = GetString(element, "displayName")?.Trim();
+                    result.Add(new S2SAllowedTenant(
+                        tenantId,
+                        string.IsNullOrWhiteSpace(displayName) ? tenantId : displayName));
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Case-insensitive membership test by tenant id.</summary>
+        public static bool Contains(IReadOnlyList<S2SAllowedTenant> tenants, string? tenantId)
+        {
+            if (tenants is null || string.IsNullOrWhiteSpace(tenantId))
+            {
+                return false;
+            }
+
+            foreach (var tenant in tenants)
+            {
+                if (string.Equals(tenant.TenantId, tenantId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string? GetString(JsonElement element, string propertyName)
+            => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+    }
+}

--- a/SafeExchange.Core/Functions/SafeExchangeApplicationSearch.cs
+++ b/SafeExchange.Core/Functions/SafeExchangeApplicationSearch.cs
@@ -1,0 +1,132 @@
+/// <summary>
+/// SafeExchangeApplicationSearch — POST /v2/application-search. Lets an authenticated
+/// USER search the locally-registered S2S applications by display name so they can add
+/// one to a secret's access list. Mirrors the user/group search endpoints (same auth
+/// gate, same SearchInput contract, applications forbidden as callers) but reads the
+/// local Applications collection instead of Microsoft Graph.
+/// </summary>
+
+namespace SafeExchange.Core.Functions
+{
+    using Microsoft.Azure.Functions.Worker.Http;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using SafeExchange.Core.Filters;
+    using SafeExchange.Core.Model;
+    using SafeExchange.Core.Model.Dto.Input;
+    using SafeExchange.Core.Model.Dto.Output;
+    using SafeExchange.Core.Telemetry;
+    using SafeExchange.Core.Utilities;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Security.Claims;
+
+    public class SafeExchangeApplicationSearch
+    {
+        /// <summary>Upper bound on returned hits — the picker is for narrowing by name, not bulk listing.</summary>
+        public const int MaxResults = 50;
+
+        private readonly SafeExchangeDbContext dbContext;
+
+        private readonly ITokenHelper tokenHelper;
+
+        private readonly GlobalFilters globalFilters;
+
+        public SafeExchangeApplicationSearch(SafeExchangeDbContext dbContext, ITokenHelper tokenHelper, GlobalFilters globalFilters)
+        {
+            this.globalFilters = globalFilters ?? throw new ArgumentNullException(nameof(globalFilters));
+            this.tokenHelper = tokenHelper ?? throw new ArgumentNullException(nameof(tokenHelper));
+            this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        }
+
+        public async Task<HttpResponseData> RunSearch(
+            HttpRequestData request, ClaimsPrincipal principal, ILogger log)
+        {
+            var (shouldReturn, filterResponse) = await this.globalFilters.GetFilterResultAsync(request, principal, this.dbContext);
+            if (shouldReturn)
+            {
+                return filterResponse ?? request.CreateResponse(HttpStatusCode.NoContent);
+            }
+
+            (SubjectType subjectType, string subjectId) = await SubjectHelper.GetSubjectInfoAsync(this.tokenHelper, principal, this.dbContext);
+            if (SubjectType.Application.Equals(subjectType))
+            {
+                return await ActionResults.ForbiddenAsync(request, "Applications cannot use this API.");
+            }
+
+            log.LogInformation($"{nameof(SafeExchangeApplicationSearch)} triggered by {subjectType} (tid {TelemetryContext.Current}), [{request.Method}].");
+
+            switch (request.Method.ToLower())
+            {
+                case "post":
+                    return await this.HandleSearchApplication(request, log);
+
+                default:
+                    return await ActionResults.CreateResponseAsync(
+                        request, HttpStatusCode.BadRequest,
+                        new BaseResponseObject<object> { Status = "error", Error = $"Request method '{request.Method}' not allowed." });
+            }
+        }
+
+        private async Task<HttpResponseData> HandleSearchApplication(HttpRequestData request, ILogger log)
+            => await ActionResults.TryCatchAsync(request, async () =>
+            {
+                var searchInput = await this.TryGetSearchInputAsync(request, log);
+                if (searchInput == null)
+                {
+                    log.LogInformation($"Search data is not provided.");
+                    return await ActionResults.CreateResponseAsync(
+                        request, HttpStatusCode.BadRequest,
+                        new BaseResponseObject<object> { Status = "error", Error = "Search data is not provided." });
+                }
+
+                if (!SearchStringValidator.TryValidate(searchInput.SearchString, out var validationError))
+                {
+                    log.LogWarning("Rejected application-search input: {Reason}", validationError);
+                    return await ActionResults.CreateResponseAsync(
+                        request, HttpStatusCode.BadRequest,
+                        new BaseResponseObject<object> { Status = "error", Error = validationError });
+                }
+
+                var term = searchInput.SearchString.Trim().ToLower();
+
+                // Filter server-side (enabled + name match), then order/cap in memory to
+                // avoid Cosmos composite-index requirements for OrderBy. The name match
+                // mirrors the admin application search.
+                var matches = await this.dbContext.Applications
+                    .Where(a => a.Enabled && a.DisplayName.ToLower().Contains(term))
+                    .ToListAsync();
+
+                var results = matches
+                    .OrderBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)
+                    .Take(MaxResults)
+                    .Select(a => new ApplicationSearchOutput
+                    {
+                        DisplayName = a.DisplayName,
+                        AadClientId = a.AadClientId,
+                        AadTenantId = a.AadTenantId,
+                    })
+                    .ToList();
+
+                return await ActionResults.CreateResponseAsync(
+                    request, HttpStatusCode.OK,
+                    new BaseResponseObject<List<ApplicationSearchOutput>> { Status = "ok", Result = results });
+            }, nameof(HandleSearchApplication), log);
+
+        private async Task<SearchInput?> TryGetSearchInputAsync(HttpRequestData request, ILogger log)
+        {
+            var requestBody = await new StreamReader(request.Body).ReadToEndAsync();
+            try
+            {
+                return DefaultJsonSerializer.Deserialize<SearchInput>(requestBody);
+            }
+            catch (Exception exception)
+            {
+                log.LogWarning(exception, "Could not parse input data for search input.");
+                return null;
+            }
+        }
+    }
+}

--- a/SafeExchange.Core/Functions/SafeExchangeS2SApps.cs
+++ b/SafeExchange.Core/Functions/SafeExchangeS2SApps.cs
@@ -37,6 +37,7 @@ namespace SafeExchange.Core.Functions
         private readonly IApplicationOwnerService ownerService;
         private readonly IOptionsMonitor<Features> features;
         private readonly IOptionsMonitor<Limits> limits;
+        private readonly IOptionsMonitor<AuthenticationConfiguration> authConfig;
 
         public SafeExchangeS2SApps(
             SafeExchangeDbContext dbContext,
@@ -44,7 +45,8 @@ namespace SafeExchange.Core.Functions
             GlobalFilters globalFilters,
             IApplicationOwnerService ownerService,
             IOptionsMonitor<Features> features,
-            IOptionsMonitor<Limits> limits)
+            IOptionsMonitor<Limits> limits,
+            IOptionsMonitor<AuthenticationConfiguration> authConfig)
         {
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
             this.tokenHelper = tokenHelper ?? throw new ArgumentNullException(nameof(tokenHelper));
@@ -52,6 +54,7 @@ namespace SafeExchange.Core.Functions
             this.ownerService = ownerService ?? throw new ArgumentNullException(nameof(ownerService));
             this.features = features ?? throw new ArgumentNullException(nameof(features));
             this.limits = limits ?? throw new ArgumentNullException(nameof(limits));
+            this.authConfig = authConfig ?? throw new ArgumentNullException(nameof(authConfig));
         }
 
         private string RegistrarCreatedBy(string upn) => $"User {upn}";
@@ -130,6 +133,16 @@ namespace SafeExchange.Core.Functions
                 if (string.IsNullOrWhiteSpace(tenantId) || !Regex.IsMatch(tenantId, GuidRegex))
                 {
                     return await BadRequestAsync(request, "AadTenantId is missing or not a GUID; pass it explicitly if the caller's token does not carry one.");
+                }
+
+                // When the operator has configured an S2S tenant allowlist, registration is
+                // restricted to those tenants — an app registered for a tenant we don't accept
+                // app tokens from could never authenticate. An empty allowlist (feature off)
+                // keeps the legacy behavior (any tenant, defaulting to the caller's home tenant).
+                var allowedTenants = S2SAllowedTenant.ParseList(this.authConfig.CurrentValue.S2SAllowedTenants);
+                if (allowedTenants.Count > 0 && !S2SAllowedTenant.Contains(allowedTenants, tenantId))
+                {
+                    return await BadRequestAsync(request, "The selected tenant is not in the configured list of tenants allowed for S2S applications.");
                 }
 
                 var contactEmail = string.IsNullOrWhiteSpace(input.ContactEmail) ? subjectId : input.ContactEmail;
@@ -265,6 +278,32 @@ namespace SafeExchange.Core.Functions
                     request, HttpStatusCode.OK,
                     new BaseResponseObject<List<S2SAppOverviewOutput>> { Status = "ok", Result = overviews });
             }, nameof(RunListMine), log);
+        }
+
+        /// <summary>
+        /// GET /s2sapps-allowed-tenants — the operator-configured tenants a user may pick
+        /// when registering an S2S app. Empty list when the allowlist is not configured, so
+        /// the client can hide/disable the tenant control and fall back to the home tenant.
+        /// </summary>
+        public async Task<HttpResponseData> RunListAllowedTenants(HttpRequestData request, ClaimsPrincipal principal, ILogger log)
+        {
+            var gate = await this.GateAsync(request, principal);
+            if (gate.shouldReturn)
+            {
+                return gate.response!;
+            }
+
+            return await ActionResults.TryCatchAsync(request, async () =>
+            {
+                var allowed = S2SAllowedTenant.ParseList(this.authConfig.CurrentValue.S2SAllowedTenants);
+                var dto = allowed
+                    .Select(t => new S2SAllowedTenantOutput { TenantId = t.TenantId, DisplayName = t.DisplayName })
+                    .ToList();
+
+                return await ActionResults.CreateResponseAsync(
+                    request, HttpStatusCode.OK,
+                    new BaseResponseObject<List<S2SAllowedTenantOutput>> { Status = "ok", Result = dto });
+            }, nameof(RunListAllowedTenants), log);
         }
 
         internal static S2SAppOutput ToDto(Application app, IReadOnlyCollection<ApplicationOwner> owners) => new()

--- a/SafeExchange.Core/Model/Dto/Output/ApplicationSearchOutput.cs
+++ b/SafeExchange.Core/Model/Dto/Output/ApplicationSearchOutput.cs
@@ -1,0 +1,17 @@
+/// <summary>
+/// ApplicationSearchOutput — a single hit from POST /v2/application-search. Carries
+/// the client/tenant id alongside the display name so the access picker can show
+/// disambiguating detail for multi-tenant apps that share a similar name.
+/// </summary>
+
+namespace SafeExchange.Core.Model.Dto.Output
+{
+    public class ApplicationSearchOutput
+    {
+        public string DisplayName { get; set; }
+
+        public string AadClientId { get; set; }
+
+        public string AadTenantId { get; set; }
+    }
+}

--- a/SafeExchange.Core/Model/Dto/Output/S2SAllowedTenantOutput.cs
+++ b/SafeExchange.Core/Model/Dto/Output/S2SAllowedTenantOutput.cs
@@ -1,0 +1,15 @@
+/// <summary>
+/// S2SAllowedTenantOutput — a tenant the operator permits for S2S app registration,
+/// returned by GET /v2/s2sapps-allowed-tenants to populate the registration tenant
+/// picker. DisplayName is the operator-supplied label (falls back to the tenant id).
+/// </summary>
+
+namespace SafeExchange.Core.Model.Dto.Output
+{
+    public class S2SAllowedTenantOutput
+    {
+        public string TenantId { get; set; }
+
+        public string DisplayName { get; set; }
+    }
+}

--- a/SafeExchange.Core/SafeExchangeStartup.cs
+++ b/SafeExchange.Core/SafeExchangeStartup.cs
@@ -205,6 +205,7 @@ namespace SafeExchange.Core
 
             services.Configure<Features>(configuration.GetSection("Features"));
             services.Configure<Limits>(configuration.GetSection("Limits"));
+            services.Configure<AuthenticationConfiguration>(configuration.GetSection("Authentication"));
             services.Configure<OrphanedSecretConfiguration>(configuration.GetSection("OrphanedSecret"));
             services.Configure<PinnedSecretsConfiguration>(configuration.GetSection("PinnedSecrets"));
             services.Configure<GloballyAllowedGroupsConfiguration>(configuration.GetSection("GlobalAllowLists"));

--- a/SafeExchange.Core/Utilities/S2SIssuerValidator.cs
+++ b/SafeExchange.Core/Utilities/S2SIssuerValidator.cs
@@ -28,7 +28,11 @@ namespace SafeExchange.Core.Utilities
             this.s2sIssuers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var tenant in allowedTenants ?? Array.Empty<S2SAllowedTenant>())
             {
-                // Both the AAD v2 and v1 issuer forms for the tenant.
+                // Both the AAD v2 and v1 issuer forms for the tenant, on the worldwide
+                // commercial cloud (which is what this feature targets). National clouds
+                // (.us/.cn) and CIAM/B2C (ciamlogin.com) issuers are intentionally not
+                // generated — a token from those simply fails closed (issuer not matched)
+                // rather than being wrongly accepted.
                 this.s2sIssuers.Add($"https://login.microsoftonline.com/{tenant.TenantId}/v2.0");
                 this.s2sIssuers.Add($"https://sts.windows.net/{tenant.TenantId}/");
             }

--- a/SafeExchange.Core/Utilities/S2SIssuerValidator.cs
+++ b/SafeExchange.Core/Utilities/S2SIssuerValidator.cs
@@ -1,0 +1,64 @@
+/// <summary>
+/// S2SIssuerValidator — token-kind-aware issuer validation backing the cross-tenant
+/// S2S feature. The configured (home-tenant) issuers are accepted for BOTH user and
+/// app tokens — unchanged behavior. Issuers derived from the S2S allowlist are
+/// accepted ONLY for app-only (client-credentials) tokens, so a user signing in from
+/// an allowlisted tenant is still rejected. Because the AAD `iss` claim is part of the
+/// signed token, this allowlist is a sound tenant gate on top of signature + audience
+/// + the (clientId, tenantId) registration check.
+/// </summary>
+
+namespace SafeExchange.Core.Utilities
+{
+    using Microsoft.IdentityModel.Tokens;
+    using SafeExchange.Core.Configuration;
+    using System;
+    using System.Collections.Generic;
+
+    public sealed class S2SIssuerValidator
+    {
+        private readonly HashSet<string> configuredIssuers;
+        private readonly HashSet<string> s2sIssuers;
+
+        public S2SIssuerValidator(IEnumerable<string> configuredIssuers, IReadOnlyList<S2SAllowedTenant> allowedTenants)
+        {
+            ArgumentNullException.ThrowIfNull(configuredIssuers);
+
+            this.configuredIssuers = new HashSet<string>(configuredIssuers, StringComparer.OrdinalIgnoreCase);
+            this.s2sIssuers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var tenant in allowedTenants ?? Array.Empty<S2SAllowedTenant>())
+            {
+                // Both the AAD v2 and v1 issuer forms for the tenant.
+                this.s2sIssuers.Add($"https://login.microsoftonline.com/{tenant.TenantId}/v2.0");
+                this.s2sIssuers.Add($"https://sts.windows.net/{tenant.TenantId}/");
+            }
+        }
+
+        /// <summary>The derived set of issuers accepted for app-only tokens (test/diagnostic visibility).</summary>
+        public IReadOnlyCollection<string> S2SIssuers => this.s2sIssuers;
+
+        /// <summary>
+        /// Returns <paramref name="issuer"/> when valid for the given token kind;
+        /// throws <see cref="SecurityTokenInvalidIssuerException"/> otherwise. The
+        /// message is intentionally generic — the auth middleware never echoes it to
+        /// the caller (CWE-209).
+        /// </summary>
+        public string Validate(string issuer, bool isAppOnlyToken)
+        {
+            if (this.configuredIssuers.Contains(issuer))
+            {
+                return issuer;
+            }
+
+            if (isAppOnlyToken && this.s2sIssuers.Contains(issuer))
+            {
+                return issuer;
+            }
+
+            throw new SecurityTokenInvalidIssuerException("Issuer is not valid for this token kind.")
+            {
+                InvalidIssuer = issuer,
+            };
+        }
+    }
+}

--- a/SafeExchange.Core/Utilities/TokenClassification.cs
+++ b/SafeExchange.Core/Utilities/TokenClassification.cs
@@ -1,0 +1,55 @@
+/// <summary>
+/// TokenClassification — the single source of truth for distinguishing an
+/// app-only (client-credentials) token from a delegated user token, based purely
+/// on the presence of claims. AAD v1 app tokens carry appid/appidacr; AAD v2 app
+/// tokens carry azp/azpacr. A delegated user token additionally carries a scope
+/// claim (scp/scope). Classifying a v2 app principal as a user would let it bypass
+/// the registered-application gate (CWE-287), so both <see cref="TokenHelper"/>
+/// (live auth path) and the S2S issuer validator consume this helper to stay in
+/// lock-step.
+/// </summary>
+
+namespace SafeExchange.Core.Utilities
+{
+    using System;
+    using System.Linq;
+
+    public static class TokenClassification
+    {
+        private const string AppIdClaim = "appid";
+        private const string AppIdAcrClaim = "appidacr";
+        private const string AzpClaim = "azp";
+        private const string AzpAcrClaim = "azpacr";
+
+        private static readonly string[] DelegatedScopeClaims =
+        {
+            "http://schemas.microsoft.com/identity/claims/scope",
+            "scope",
+            "scp",
+        };
+
+        /// <summary>True when the token carries a full app-credential claim pair (v1 or v2).</summary>
+        public static bool HasAppCredentialClaims(Func<string, bool> hasClaim)
+        {
+            ArgumentNullException.ThrowIfNull(hasClaim);
+
+            return (hasClaim(AppIdClaim) && hasClaim(AppIdAcrClaim))
+                || (hasClaim(AzpClaim) && hasClaim(AzpAcrClaim));
+        }
+
+        /// <summary>True when the token carries any delegated (user) scope claim.</summary>
+        public static bool HasDelegatedScopeClaim(Func<string, bool> hasClaim)
+        {
+            ArgumentNullException.ThrowIfNull(hasClaim);
+
+            return DelegatedScopeClaims.Any(hasClaim);
+        }
+
+        /// <summary>
+        /// True for an app-only (client-credentials) token: it has app-credential
+        /// claims and NO delegated scope claim.
+        /// </summary>
+        public static bool IsAppOnlyToken(Func<string, bool> hasClaim)
+            => HasAppCredentialClaims(hasClaim) && !HasDelegatedScopeClaim(hasClaim);
+    }
+}

--- a/SafeExchange.Core/Utilities/TokenHelper.cs
+++ b/SafeExchange.Core/Utilities/TokenHelper.cs
@@ -12,6 +12,7 @@ namespace SafeExchange.Core
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Utilities;
 
     public class TokenHelper : ITokenHelper
     {
@@ -48,29 +49,20 @@ namespace SafeExchange.Core
 
         /// <inheritdoc/>
         public TokenType GetTokenType(ClaimsPrincipal principal)
-        {
             // AAD v1 app tokens carry appid/appidacr; AAD v2 app tokens (including
             // client-credentials / app-only) carry azp/azpacr instead. Classify both
             // as access tokens so v2 app principals are not misclassified as users
-            // and thus bypass the registered-application gate (CWE-287). This stays
-            // consistent with GetApplicationClientId, which reads azp before appid.
-            if ((HasClaim(principal, "appid") && HasClaim(principal, "appidacr")) ||
-                (HasClaim(principal, "azp") && HasClaim(principal, "azpacr")))
-            {
-                return TokenType.AccessToken;
-            }
-
-            return TokenType.IdToken;
-        }
+            // and thus bypass the registered-application gate (CWE-287). Shared with
+            // the S2S issuer validator via TokenClassification so the two cannot drift.
+            => TokenClassification.HasAppCredentialClaims(type => HasClaim(principal, type))
+                ? TokenType.AccessToken
+                : TokenType.IdToken;
 
         /// <inheritdoc/>
         public bool IsUserToken(ClaimsPrincipal principal)
         {
             var tokenType = this.GetTokenType(principal);
-            var result = (tokenType == TokenType.IdToken) ||
-                (HasClaim(principal, "http://schemas.microsoft.com/identity/claims/scope") ||
-                HasClaim(principal, "scope") ||
-                HasClaim(principal, "scp"));
+            var result = !TokenClassification.IsAppOnlyToken(type => HasClaim(principal, type));
 
             this.log.LogInformation("Principal is authenticated as {AuthKind} with {TokenType}.", result ? "a user" : "an app", tokenType);
             return result;

--- a/SafeExchange.Core/Utilities/TokenValidationParametersProvider.cs
+++ b/SafeExchange.Core/Utilities/TokenValidationParametersProvider.cs
@@ -9,7 +9,10 @@ namespace SafeExchange.Core
     using Microsoft.IdentityModel.Protocols;
     using Microsoft.IdentityModel.Tokens;
     using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Utilities;
     using System.Configuration;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Linq;
     using Microsoft.Extensions.Logging;
     using System.Text;
     using Microsoft.IdentityModel.Validators;
@@ -91,7 +94,36 @@ namespace SafeExchange.Core
                 },
             };
 
-            this.tokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+            var allowedS2STenants = S2SAllowedTenant.ParseList(authConfig.S2SAllowedTenants, this.log);
+            if (allowedS2STenants.Count == 0)
+            {
+                // No S2S allowlist configured — preserve the existing single-tenant
+                // hardening exactly: the AAD signing-key↔issuer binding on top of the
+                // ValidIssuers allowlist. Behavior is byte-for-byte unchanged.
+                this.tokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+            }
+            else
+            {
+                // Cross-tenant S2S. Accept APP-ONLY tokens from the configured home tenant
+                // OR any allowlisted tenant, while still restricting USER tokens to the home
+                // tenant. The signed `iss` claim + this fixed allowlist is the tenant gate.
+                // EnableAadSigningKeyIssuerValidation() binds the signing key to the single
+                // configured issuer and would reject allowlisted tenants, so it is intentionally
+                // not applied here; signature validation against the global AAD signing keys,
+                // audience validation, and the (clientId, tenantId) registration check in
+                // TokenMiddlewareCore all remain in force as defense in depth.
+                var s2sIssuerValidator = new S2SIssuerValidator(validIssuers, allowedS2STenants);
+                this.tokenValidationParameters.IssuerValidator = (issuer, securityToken, _) =>
+                {
+                    var isAppOnly = securityToken is JwtSecurityToken jwt
+                        && TokenClassification.IsAppOnlyToken(type => jwt.Claims.Any(claim => claim.Type == type));
+                    return s2sIssuerValidator.Validate(issuer, isAppOnly);
+                };
+
+                this.log.LogInformation(
+                    "S2S cross-tenant issuer validation enabled for {Count} allowlisted tenant(s).",
+                    allowedS2STenants.Count);
+            }
 
             this.openIdConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 authConfig.MetadataAddress, new OpenIdConnectConfigurationRetriever());

--- a/SafeExchange.Functions/Functions/SafeApplicationSearch.cs
+++ b/SafeExchange.Functions/Functions/SafeApplicationSearch.cs
@@ -1,0 +1,39 @@
+/// <summary>
+/// SafeApplicationSearch — HTTP trigger for POST /v2/application-search. Thin wrapper
+/// that delegates to the SafeExchangeApplicationSearch handler, mirroring SafeUserSearch.
+/// </summary>
+
+namespace SafeExchange.Functions.Functions
+{
+    using Microsoft.Azure.Functions.Worker;
+    using Microsoft.Azure.Functions.Worker.Http;
+    using Microsoft.Extensions.Logging;
+    using SafeExchange.Core;
+    using SafeExchange.Core.Filters;
+    using SafeExchange.Core.Functions;
+    using System;
+
+    public class SafeApplicationSearch
+    {
+        private const string Version = "v2";
+
+        private readonly SafeExchangeApplicationSearch safeExchangeApplicationSearchHandler;
+
+        private readonly ILogger log;
+
+        public SafeApplicationSearch(SafeExchangeDbContext dbContext, ITokenHelper tokenHelper, GlobalFilters globalFilters, ILogger<SafeApplicationSearch> log)
+        {
+            this.safeExchangeApplicationSearchHandler = new SafeExchangeApplicationSearch(dbContext, tokenHelper, globalFilters);
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        [Function("SafeExchange-ApplicationSearch")]
+        public async Task<HttpResponseData> RunApplicationSearch(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = $"{Version}/application-search")]
+            HttpRequestData request)
+        {
+            var principal = request.FunctionContext.GetPrincipal();
+            return await this.safeExchangeApplicationSearchHandler.RunSearch(request, principal, this.log);
+        }
+    }
+}

--- a/SafeExchange.Functions/Functions/SafeS2SApps.cs
+++ b/SafeExchange.Functions/Functions/SafeS2SApps.cs
@@ -32,9 +32,10 @@ namespace SafeExchange.Functions
             IApplicationOwnerService ownerService,
             IOptionsMonitor<Features> features,
             IOptionsMonitor<Limits> limits,
+            IOptionsMonitor<AuthenticationConfiguration> authConfig,
             ILogger<SafeS2SApps> log)
         {
-            this.handler = new SafeExchangeS2SApps(dbContext, tokenHelper, globalFilters, ownerService, features, limits);
+            this.handler = new SafeExchangeS2SApps(dbContext, tokenHelper, globalFilters, ownerService, features, limits, authConfig);
             this.log = log ?? throw new ArgumentNullException(nameof(log));
         }
 
@@ -45,6 +46,17 @@ namespace SafeExchange.Functions
         {
             var principal = request.FunctionContext.GetPrincipal();
             return await this.handler.RunRegister(request, principal, this.log);
+        }
+
+        [Function("SafeExchange-S2SApps-AllowedTenants")]
+        public async Task<HttpResponseData> RunListAllowedTenants(
+            // Sibling route (not under /s2sapps/{displayName}) so it can't be mistaken
+            // for an app display name by the route matcher.
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = $"{Version}/s2sapps-allowed-tenants")]
+            HttpRequestData request)
+        {
+            var principal = request.FunctionContext.GetPrincipal();
+            return await this.handler.RunListAllowedTenants(request, principal, this.log);
         }
 
         [Function("SafeExchange-S2SApps-Mine")]

--- a/SafeExchange.Tests/Tests/ApplicationSearchTests.cs
+++ b/SafeExchange.Tests/Tests/ApplicationSearchTests.cs
@@ -1,0 +1,200 @@
+/// <summary>
+/// ApplicationSearchTests — end-to-end (EF InMemory) tests for POST /v2/application-search,
+/// the backend behind the access-list application picker. Verifies name matching, that only
+/// enabled apps are returned, that disambiguation fields are populated, that the search string
+/// is validated, and that application callers are forbidden (apps must not enumerate apps).
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Azure.Core.Serialization;
+    using Microsoft.Azure.Functions.Worker;
+    using Microsoft.Azure.Functions.Worker.Http;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using NUnit.Framework;
+    using SafeExchange.Core;
+    using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Filters;
+    using SafeExchange.Core.Functions;
+    using SafeExchange.Core.Model;
+    using SafeExchange.Core.Model.Dto.Input;
+    using SafeExchange.Core.Model.Dto.Output;
+    using Microsoft.EntityFrameworkCore;
+    using SafeExchange.Tests.Utilities;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class ApplicationSearchTests
+    {
+        private ILogger logger = null!;
+        private SafeExchangeDbContext dbContext = null!;
+        private ITokenHelper userTokenHelper = null!;
+        private GlobalFilters globalFilters = null!;
+        private SafeExchangeApplicationSearch handler = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            this.logger = TestFactory.CreateLogger();
+
+            var dbContextOptions = new DbContextOptionsBuilder<SafeExchangeDbContext>()
+                .UseInMemoryDatabase($"{nameof(ApplicationSearchTests)}-{Guid.NewGuid()}")
+                .Options;
+            this.dbContext = new SafeExchangeDbContext(dbContextOptions);
+
+            this.userTokenHelper = new TestTokenHelper();
+            this.globalFilters = CreateGlobalFilters(this.userTokenHelper);
+
+            var workerOptions = Options.Create(new WorkerOptions() { Serializer = new JsonObjectSerializer() });
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            serviceProviderMock.Setup(x => x.GetService(typeof(IOptions<WorkerOptions>))).Returns(workerOptions);
+            TestFactory.FunctionContext.InstanceServices = serviceProviderMock.Object;
+
+            this.SeedApplications();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeCleanup()
+        {
+            this.dbContext.Database.EnsureDeleted();
+            this.dbContext.Dispose();
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.handler = new SafeExchangeApplicationSearch(this.dbContext, this.userTokenHelper, this.globalFilters);
+        }
+
+        private static GlobalFilters CreateGlobalFilters(ITokenHelper tokenHelper)
+        {
+            var groups = Mock.Of<IOptionsMonitor<GloballyAllowedGroupsConfiguration>>(
+                x => x.CurrentValue == new GloballyAllowedGroupsConfiguration());
+            var admin = Mock.Of<IOptionsMonitor<AdminConfiguration>>(
+                x => x.CurrentValue == new AdminConfiguration());
+            return new GlobalFilters(groups, admin, tokenHelper, TestFactory.CreateLogger<GlobalFilters>());
+        }
+
+        private void SeedApplications()
+        {
+            App("PaymentService", "11111111-1111-1111-1111-111111111111", "aaaaaaaa-0000-0000-0000-000000000001", enabled: true);
+            App("PaymentGateway", "11111111-1111-1111-1111-111111111111", "aaaaaaaa-0000-0000-0000-000000000002", enabled: true);
+            App("BillingDaemon", "22222222-2222-2222-2222-222222222222", "aaaaaaaa-0000-0000-0000-000000000003", enabled: true);
+            App("RetiredPaymentApp", "11111111-1111-1111-1111-111111111111", "aaaaaaaa-0000-0000-0000-000000000004", enabled: false);
+            this.dbContext.SaveChanges();
+        }
+
+        private void App(string displayName, string tenantId, string clientId, bool enabled)
+            => this.dbContext.Applications.Add(new Application
+            {
+                Id = Guid.NewGuid().ToString(),
+                PartitionKey = Application.DefaultPartitionKey,
+                DisplayName = displayName,
+                AadTenantId = tenantId,
+                AadClientId = clientId,
+                ContactEmail = "owner@test.test",
+                Enabled = enabled,
+                CreatedBy = "User owner@test.test",
+                ModifiedBy = string.Empty,
+            });
+
+        private static ClaimsPrincipal User()
+            => new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim("upn", "searcher@test.test"),
+                new Claim("oid", "00000000-0000-0000-0000-0000000000b1"),
+                new Claim("tid", "00000000-0000-0000-0000-000000000001"),
+            }));
+
+        private async Task<TestHttpResponseData> SearchAsync(ITokenHelper tokenHelper, ClaimsPrincipal principal, string searchString)
+        {
+            var localHandler = new SafeExchangeApplicationSearch(this.dbContext, tokenHelper, CreateGlobalFilters(tokenHelper));
+            var request = TestFactory.CreateHttpRequestData("post");
+            request.SetBodyAsJson(new SearchInput { SearchString = searchString });
+            return await localHandler.RunSearch(request, principal, this.logger) as TestHttpResponseData
+                ?? throw new InvalidOperationException("null response");
+        }
+
+        [Test]
+        public async Task Search_returns_matching_enabled_apps_with_disambiguation_fields()
+        {
+            var request = TestFactory.CreateHttpRequestData("post");
+            request.SetBodyAsJson(new SearchInput { SearchString = "payment" });
+
+            var response = await this.handler.RunSearch(request, User(), this.logger) as TestHttpResponseData;
+
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = response.ReadBodyAsJson<BaseResponseObject<List<ApplicationSearchOutput>>>();
+            var names = body!.Result!.Select(a => a.DisplayName).ToList();
+
+            Assert.That(names, Does.Contain("PaymentService"));
+            Assert.That(names, Does.Contain("PaymentGateway"));
+            Assert.That(names, Does.Not.Contain("BillingDaemon"), "non-matching app must be excluded");
+            Assert.That(names, Does.Not.Contain("RetiredPaymentApp"), "disabled app must be excluded");
+
+            var first = body.Result!.First(a => a.DisplayName == "PaymentService");
+            Assert.That(first.AadClientId, Is.EqualTo("aaaaaaaa-0000-0000-0000-000000000001"));
+            Assert.That(first.AadTenantId, Is.EqualTo("11111111-1111-1111-1111-111111111111"));
+        }
+
+        [Test]
+        public async Task Search_is_case_insensitive_substring()
+        {
+            var response = await this.SearchAsync(this.userTokenHelper, User(), "GATEWAY");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = response.ReadBodyAsJson<BaseResponseObject<List<ApplicationSearchOutput>>>();
+            Assert.That(body!.Result!.Select(a => a.DisplayName), Is.EqualTo(new[] { "PaymentGateway" }));
+        }
+
+        [Test]
+        public async Task Search_with_empty_string_is_bad_request()
+        {
+            var response = await this.SearchAsync(this.userTokenHelper, User(), "   ");
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public async Task Search_with_overlong_string_is_bad_request()
+        {
+            var response = await this.SearchAsync(this.userTokenHelper, User(), new string('a', 65));
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public async Task Search_with_quote_is_bad_request()
+        {
+            var response = await this.SearchAsync(this.userTokenHelper, User(), "pay\" or true");
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        }
+
+        [Test]
+        public async Task Application_caller_is_forbidden()
+        {
+            var appTokenHelper = new AppOnlyTokenHelper();
+            var response = await this.SearchAsync(appTokenHelper, new ClaimsPrincipal(new ClaimsIdentity()), "payment");
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+        }
+
+        /// <summary>Minimal app-only token helper: classifies the caller as an application.</summary>
+        private sealed class AppOnlyTokenHelper : ITokenHelper
+        {
+            public bool IsUserToken(ClaimsPrincipal principal) => false;
+            public TokenType GetTokenType(ClaimsPrincipal principal) => TokenType.AccessToken;
+            public string GetApplicationClientId(ClaimsPrincipal principal) => "33333333-3333-3333-3333-333333333333";
+            public string? GetTenantId(ClaimsPrincipal? principal) => "44444444-4444-4444-4444-444444444444";
+            public string? GetObjectId(ClaimsPrincipal? principal) => "00000000-0000-0000-0000-0000000000c1";
+            public string GetUpn(ClaimsPrincipal principal) => string.Empty;
+            public string GetDisplayName(ClaimsPrincipal principal) => string.Empty;
+            public AccountIdAndToken GetAccountIdAndToken(HttpRequestData request, ClaimsPrincipal principal)
+                => new AccountIdAndToken(string.Empty, string.Empty);
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/S2SAllowedTenantTests.cs
+++ b/SafeExchange.Tests/Tests/S2SAllowedTenantTests.cs
@@ -1,0 +1,91 @@
+/// <summary>
+/// S2SAllowedTenantTests — unit tests for the configuration parser that turns the
+/// Authentication:S2SAllowedTenants JSON setting into a typed, validated list.
+/// Parsing must FAIL CLOSED: malformed / missing config yields an empty list
+/// (no S2S tenants trusted), never an exception that takes the app down.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using NUnit.Framework;
+    using SafeExchange.Core.Configuration;
+    using System.Linq;
+
+    [TestFixture]
+    public class S2SAllowedTenantTests
+    {
+        private const string TenantA = "11111111-1111-1111-1111-111111111111";
+        private const string TenantB = "22222222-2222-2222-2222-222222222222";
+
+        [Test]
+        public void ParseList_null_or_empty_returns_empty()
+        {
+            Assert.That(S2SAllowedTenant.ParseList(null), Is.Empty);
+            Assert.That(S2SAllowedTenant.ParseList(string.Empty), Is.Empty);
+            Assert.That(S2SAllowedTenant.ParseList("   "), Is.Empty);
+        }
+
+        [Test]
+        public void ParseList_valid_json_returns_entries()
+        {
+            var json = $"[{{\"tenantId\":\"{TenantA}\",\"displayName\":\"Contoso\"}},{{\"tenantId\":\"{TenantB}\",\"displayName\":\"Fabrikam\"}}]";
+
+            var result = S2SAllowedTenant.ParseList(json);
+
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result[0].TenantId, Is.EqualTo(TenantA));
+            Assert.That(result[0].DisplayName, Is.EqualTo("Contoso"));
+            Assert.That(result[1].TenantId, Is.EqualTo(TenantB));
+            Assert.That(result[1].DisplayName, Is.EqualTo("Fabrikam"));
+        }
+
+        [Test]
+        public void ParseList_missing_displayName_defaults_to_tenantId()
+        {
+            var json = $"[{{\"tenantId\":\"{TenantA}\"}}]";
+
+            var result = S2SAllowedTenant.ParseList(json);
+
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result[0].DisplayName, Is.EqualTo(TenantA));
+        }
+
+        [Test]
+        public void ParseList_skips_non_guid_tenant_ids()
+        {
+            var json = $"[{{\"tenantId\":\"not-a-guid\"}},{{\"tenantId\":\"{TenantA}\"}}]";
+
+            var result = S2SAllowedTenant.ParseList(json);
+
+            Assert.That(result.Select(t => t.TenantId), Is.EqualTo(new[] { TenantA }));
+        }
+
+        [Test]
+        public void ParseList_malformed_json_fails_closed_to_empty()
+        {
+            Assert.That(S2SAllowedTenant.ParseList("not json at all"), Is.Empty);
+            Assert.That(S2SAllowedTenant.ParseList("{\"tenantId\":\"x\"}"), Is.Empty); // object, not array
+        }
+
+        [Test]
+        public void ParseList_dedupes_by_tenant_id_case_insensitive_keeping_first()
+        {
+            var json = $"[{{\"tenantId\":\"{TenantA}\",\"displayName\":\"First\"}},{{\"tenantId\":\"{TenantA.ToUpperInvariant()}\",\"displayName\":\"Second\"}}]";
+
+            var result = S2SAllowedTenant.ParseList(json);
+
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result[0].DisplayName, Is.EqualTo("First"));
+        }
+
+        [Test]
+        public void Contains_matches_tenant_id_case_insensitively()
+        {
+            var list = S2SAllowedTenant.ParseList($"[{{\"tenantId\":\"{TenantA}\"}}]");
+
+            Assert.That(S2SAllowedTenant.Contains(list, TenantA.ToUpperInvariant()), Is.True);
+            Assert.That(S2SAllowedTenant.Contains(list, TenantB), Is.False);
+            Assert.That(S2SAllowedTenant.Contains(list, null), Is.False);
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/S2SAppRegistrationAllowlistTests.cs
+++ b/SafeExchange.Tests/Tests/S2SAppRegistrationAllowlistTests.cs
@@ -1,0 +1,176 @@
+/// <summary>
+/// S2SAppRegistrationAllowlistTests — verifies the configuration-time S2S tenant
+/// allowlist is enforced at registration (the security boundary the owner asked for:
+/// users may only register apps under tenants the operator pre-approved) and that the
+/// allowed-tenants endpoint surfaces that list. Backward compat: an empty allowlist
+/// keeps the legacy "default to the caller's home tenant" behavior.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Azure.Core.Serialization;
+    using Microsoft.Azure.Functions.Worker;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using NUnit.Framework;
+    using SafeExchange.Core;
+    using SafeExchange.Core.Applications;
+    using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Filters;
+    using SafeExchange.Core.Functions;
+    using SafeExchange.Core.Model;
+    using SafeExchange.Core.Model.Dto.Input;
+    using SafeExchange.Core.Model.Dto.Output;
+    using SafeExchange.Tests.Utilities;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class S2SAppRegistrationAllowlistTests
+    {
+        private const string HomeTenant = "00000000-0000-0000-0000-000000000001";
+        private const string AllowedTenant = "11111111-1111-1111-1111-111111111111";
+        private const string ForeignTenant = "99999999-9999-9999-9999-999999999999";
+        private const string SomeClientId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        private ILogger logger = null!;
+        private SafeExchangeDbContext dbContext = null!;
+        private ITokenHelper tokenHelper = null!;
+        private GlobalFilters globalFilters = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            this.logger = TestFactory.CreateLogger();
+            this.tokenHelper = new TestTokenHelper();
+
+            var groups = Mock.Of<IOptionsMonitor<GloballyAllowedGroupsConfiguration>>(
+                x => x.CurrentValue == new GloballyAllowedGroupsConfiguration());
+            var admin = Mock.Of<IOptionsMonitor<AdminConfiguration>>(
+                x => x.CurrentValue == new AdminConfiguration());
+            this.globalFilters = new GlobalFilters(groups, admin, this.tokenHelper, TestFactory.CreateLogger<GlobalFilters>());
+
+            var workerOptions = Options.Create(new WorkerOptions() { Serializer = new JsonObjectSerializer() });
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            serviceProviderMock.Setup(x => x.GetService(typeof(IOptions<WorkerOptions>))).Returns(workerOptions);
+            TestFactory.FunctionContext.InstanceServices = serviceProviderMock.Object;
+
+            DateTimeProvider.SpecifiedDateTime = DateTime.UtcNow;
+            DateTimeProvider.UseSpecifiedDateTime = true;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeCleanup() => DateTimeProvider.UseSpecifiedDateTime = false;
+
+        [SetUp]
+        public void Setup()
+        {
+            var dbContextOptions = new DbContextOptionsBuilder<SafeExchangeDbContext>()
+                .UseInMemoryDatabase($"{nameof(S2SAppRegistrationAllowlistTests)}-{Guid.NewGuid()}")
+                .Options;
+            this.dbContext = new SafeExchangeDbContext(dbContextOptions);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            this.dbContext.Database.EnsureDeleted();
+            this.dbContext.Dispose();
+        }
+
+        private SafeExchangeS2SApps CreateHandler(string s2sAllowedTenantsJson)
+        {
+            var features = Mock.Of<IOptionsMonitor<Features>>(x => x.CurrentValue == new Features { S2SAppsSelfService = true });
+            var limits = Mock.Of<IOptionsMonitor<Limits>>(x => x.CurrentValue == new Limits());
+            var authConfig = Mock.Of<IOptionsMonitor<AuthenticationConfiguration>>(
+                x => x.CurrentValue == new AuthenticationConfiguration { S2SAllowedTenants = s2sAllowedTenantsJson });
+            var ownerService = new ApplicationOwnerService(this.dbContext);
+            return new SafeExchangeS2SApps(this.dbContext, this.tokenHelper, this.globalFilters, ownerService, features, limits, authConfig);
+        }
+
+        private static ClaimsPrincipal Caller()
+            => new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim("upn", "registrar@test.test"),
+                new Claim("oid", "00000000-0000-0000-0000-0000000000d1"),
+                new Claim("tid", HomeTenant),
+            }));
+
+        private static S2SAppRegistrationInput RegistrationFor(string? tenantId)
+            => new S2SAppRegistrationInput
+            {
+                DisplayName = "MyDaemonApp",
+                AadClientId = SomeClientId,
+                AadTenantId = tenantId,
+                AdditionalOwners = new List<S2SAppOwnerInput>
+                {
+                    new S2SAppOwnerInput { SubjectType = OwnerSubjectType.User, SubjectId = "coowner@test.test", SubjectName = "Co Owner" },
+                },
+            };
+
+        private async Task<TestHttpResponseData> RegisterAsync(SafeExchangeS2SApps handler, S2SAppRegistrationInput input)
+        {
+            var request = TestFactory.CreateHttpRequestData("post");
+            request.SetBodyAsJson(input);
+            return await handler.RunRegister(request, Caller(), this.logger) as TestHttpResponseData
+                ?? throw new InvalidOperationException("null response");
+        }
+
+        private static string AllowlistJson(params string[] tenantIds)
+            => "[" + string.Join(",", tenantIds.Select(t => $"{{\"tenantId\":\"{t}\",\"displayName\":\"{t}\"}}")) + "]";
+
+        [Test]
+        public async Task Register_rejects_tenant_not_in_allowlist()
+        {
+            var handler = this.CreateHandler(AllowlistJson(AllowedTenant));
+
+            var response = await this.RegisterAsync(handler, RegistrationFor(ForeignTenant));
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            Assert.That(await this.dbContext.Applications.CountAsync(), Is.EqualTo(0), "no app must be created for a disallowed tenant");
+        }
+
+        [Test]
+        public async Task Register_accepts_tenant_in_allowlist()
+        {
+            var handler = this.CreateHandler(AllowlistJson(AllowedTenant, ForeignTenant.Replace("9", "8")));
+
+            var response = await this.RegisterAsync(handler, RegistrationFor(AllowedTenant));
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+            var created = await this.dbContext.Applications.SingleAsync();
+            Assert.That(created.AadTenantId, Is.EqualTo(AllowedTenant));
+        }
+
+        [Test]
+        public async Task Register_with_empty_allowlist_defaults_to_home_tenant()
+        {
+            var handler = this.CreateHandler(string.Empty);
+
+            var response = await this.RegisterAsync(handler, RegistrationFor(null));
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+            var created = await this.dbContext.Applications.SingleAsync();
+            Assert.That(created.AadTenantId, Is.EqualTo(HomeTenant), "empty allowlist keeps the legacy home-tenant default");
+        }
+
+        [Test]
+        public async Task AllowedTenants_endpoint_returns_configured_list()
+        {
+            var handler = this.CreateHandler(AllowlistJson(AllowedTenant));
+
+            var request = TestFactory.CreateHttpRequestData("get");
+            var response = await handler.RunListAllowedTenants(request, Caller(), this.logger) as TestHttpResponseData;
+
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = response.ReadBodyAsJson<BaseResponseObject<List<S2SAllowedTenantOutput>>>();
+            Assert.That(body!.Result!.Select(t => t.TenantId), Is.EqualTo(new[] { AllowedTenant }));
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/S2SIssuerValidatorTests.cs
+++ b/SafeExchange.Tests/Tests/S2SIssuerValidatorTests.cs
@@ -1,0 +1,68 @@
+/// <summary>
+/// S2SIssuerValidatorTests — the heart of the cross-tenant S2S feature. The
+/// validator must accept app-only tokens from the configured home tenant OR any
+/// allowlisted tenant, accept user tokens ONLY from the home tenant, and reject
+/// everything else with a SecurityTokenInvalidIssuerException.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Microsoft.IdentityModel.Tokens;
+    using NUnit.Framework;
+    using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Utilities;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    public class S2SIssuerValidatorTests
+    {
+        private const string Home = "00000000-0000-0000-0000-0000000000aa";
+        private const string Allowed = "11111111-1111-1111-1111-111111111111";
+        private const string Other = "99999999-9999-9999-9999-999999999999";
+
+        private static string V2(string tid) => $"https://login.microsoftonline.com/{tid}/v2.0";
+        private static string V1(string tid) => $"https://sts.windows.net/{tid}/";
+
+        private static S2SIssuerValidator Validator()
+        {
+            var configured = new[] { V2(Home), V1(Home) };
+            var allowed = S2SAllowedTenant.ParseList($"[{{\"tenantId\":\"{Allowed}\",\"displayName\":\"Dev\"}}]");
+            return new S2SIssuerValidator(configured, allowed);
+        }
+
+        [Test]
+        public void Home_issuer_accepted_for_user_token()
+            => Assert.That(Validator().Validate(V2(Home), isAppOnlyToken: false), Is.EqualTo(V2(Home)));
+
+        [Test]
+        public void Home_issuer_accepted_for_app_token()
+            => Assert.That(Validator().Validate(V1(Home), isAppOnlyToken: true), Is.EqualTo(V1(Home)));
+
+        [Test]
+        public void Allowlisted_issuer_accepted_for_app_token_v2_and_v1()
+        {
+            Assert.That(Validator().Validate(V2(Allowed), isAppOnlyToken: true), Is.EqualTo(V2(Allowed)));
+            Assert.That(Validator().Validate(V1(Allowed), isAppOnlyToken: true), Is.EqualTo(V1(Allowed)));
+        }
+
+        [Test]
+        public void Allowlisted_issuer_rejected_for_user_token()
+            => Assert.Throws<SecurityTokenInvalidIssuerException>(
+                () => Validator().Validate(V2(Allowed), isAppOnlyToken: false));
+
+        [Test]
+        public void Unknown_issuer_rejected_for_app_token()
+            => Assert.Throws<SecurityTokenInvalidIssuerException>(
+                () => Validator().Validate(V2(Other), isAppOnlyToken: true));
+
+        [Test]
+        public void Unknown_issuer_rejected_for_user_token()
+            => Assert.Throws<SecurityTokenInvalidIssuerException>(
+                () => Validator().Validate(V2(Other), isAppOnlyToken: false));
+
+        [Test]
+        public void Issuer_match_is_case_insensitive_on_tenant_guid()
+            => Assert.That(Validator().Validate(V2(Allowed.ToUpperInvariant()), isAppOnlyToken: true),
+                Is.EqualTo(V2(Allowed.ToUpperInvariant())));
+    }
+}

--- a/SafeExchange.Tests/Tests/TokenClassificationTests.cs
+++ b/SafeExchange.Tests/Tests/TokenClassificationTests.cs
@@ -1,0 +1,61 @@
+/// <summary>
+/// TokenClassificationTests — locks in the shared rule that distinguishes an
+/// app-only (client-credentials) token from a delegated user token. The S2S
+/// issuer allowlist relaxes issuer validation ONLY for app-only tokens, so this
+/// classification is security-load-bearing (CWE-287). It must stay identical to
+/// the logic TokenHelper uses on the live auth path.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using NUnit.Framework;
+    using SafeExchange.Core.Utilities;
+    using System;
+    using System.Linq;
+
+    [TestFixture]
+    public class TokenClassificationTests
+    {
+        private static Func<string, bool> Claims(params string[] types)
+            => t => types.Contains(t, StringComparer.Ordinal);
+
+        [Test]
+        public void AppOnly_v1_appid_appidacr_without_scope_is_true()
+            => Assert.That(TokenClassification.IsAppOnlyToken(Claims("appid", "appidacr")), Is.True);
+
+        [Test]
+        public void AppOnly_v2_azp_azpacr_without_scope_is_true()
+            => Assert.That(TokenClassification.IsAppOnlyToken(Claims("azp", "azpacr")), Is.True);
+
+        [Test]
+        public void AppCredential_claims_but_with_delegated_scope_is_not_app_only()
+        {
+            Assert.That(TokenClassification.IsAppOnlyToken(Claims("appid", "appidacr", "scp")), Is.False);
+            Assert.That(TokenClassification.IsAppOnlyToken(Claims("azp", "azpacr", "scope")), Is.False);
+            Assert.That(TokenClassification.IsAppOnlyToken(
+                Claims("azp", "azpacr", "http://schemas.microsoft.com/identity/claims/scope")), Is.False);
+        }
+
+        [Test]
+        public void Partial_app_credential_claims_are_not_app_only()
+        {
+            // Needs BOTH of a pair — a lone appid (v1 delegated tokens carry appid too) must not qualify.
+            Assert.That(TokenClassification.IsAppOnlyToken(Claims("appid")), Is.False);
+            Assert.That(TokenClassification.IsAppOnlyToken(Claims("azp")), Is.False);
+        }
+
+        [Test]
+        public void No_claims_is_not_app_only()
+            => Assert.That(TokenClassification.IsAppOnlyToken(Claims()), Is.False);
+
+        [Test]
+        public void HasDelegatedScopeClaim_recognizes_all_three_forms()
+        {
+            Assert.That(TokenClassification.HasDelegatedScopeClaim(Claims("scp")), Is.True);
+            Assert.That(TokenClassification.HasDelegatedScopeClaim(Claims("scope")), Is.True);
+            Assert.That(TokenClassification.HasDelegatedScopeClaim(
+                Claims("http://schemas.microsoft.com/identity/claims/scope")), Is.True);
+            Assert.That(TokenClassification.HasDelegatedScopeClaim(Claims("appid")), Is.False);
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/TokenValidationParametersProviderTests.cs
+++ b/SafeExchange.Tests/Tests/TokenValidationParametersProviderTests.cs
@@ -12,7 +12,9 @@ namespace SafeExchange.Tests
     using SafeExchange.Core;
     using System.Collections.Generic;
     using System.Configuration;
+    using System.IdentityModel.Tokens.Jwt;
     using System.Linq;
+    using System.Security.Claims;
 
     /// <summary>
     /// Tests for <see cref="TokenValidationParametersProvider"/>'s startup
@@ -186,6 +188,60 @@ namespace SafeExchange.Tests
             Assert.That(tvp.ValidAlgorithms, Does.Contain(SecurityAlgorithms.RsaSha256));
 
             await System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        [Test]
+        public void Ctor_WithS2SAllowedTenants_InstallsTokenKindAwareIssuerValidator()
+        {
+            const string allowedTid = "11111111-1111-1111-1111-111111111111";
+            var configuration = BuildConfiguration(
+                ("Authentication:MetadataAddress", "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"),
+                ("Authentication:ValidateAudience", "true"),
+                ("Authentication:ValidAudiences", "api://app"),
+                ("Authentication:ValidateIssuer", "true"),
+                ("Authentication:ValidIssuers", "https://login.microsoftonline.com/00000000-0000-0000-0000-0000000000aa/v2.0"),
+                ("Authentication:S2SAllowedTenants", $"[{{\"tenantId\":\"{allowedTid}\",\"displayName\":\"Dev\"}}]"));
+
+            var provider = new TokenValidationParametersProvider(configuration, this.logger);
+            var tvp = ReadParameters(provider);
+
+            Assert.That(tvp.IssuerValidator, Is.Not.Null, "a custom issuer validator must be installed when the allowlist is non-empty.");
+
+            var allowedIssuer = $"https://login.microsoftonline.com/{allowedTid}/v2.0";
+
+            // App-only token (azp/azpacr, no scope) from an allowlisted tenant: accepted.
+            var appToken = new JwtSecurityToken(claims: new[] { new Claim("azp", "x"), new Claim("azpacr", "1") });
+            Assert.That(tvp.IssuerValidator(allowedIssuer, appToken, tvp), Is.EqualTo(allowedIssuer));
+
+            // User token (carries scope) from the same allowlisted tenant: rejected.
+            var userToken = new JwtSecurityToken(claims: new[] { new Claim("azp", "x"), new Claim("azpacr", "1"), new Claim("scp", "user_impersonation") });
+            Assert.Throws<SecurityTokenInvalidIssuerException>(
+                () => tvp.IssuerValidator(allowedIssuer, userToken, tvp));
+        }
+
+        [Test]
+        public void Ctor_WithoutS2SAllowedTenants_NoCustomIssuerValidator()
+        {
+            var configuration = BuildConfiguration(
+                ("Authentication:MetadataAddress", "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"),
+                ("Authentication:ValidateAudience", "true"),
+                ("Authentication:ValidAudiences", "api://app"),
+                ("Authentication:ValidateIssuer", "true"),
+                ("Authentication:ValidIssuers", "https://login.microsoftonline.com/00000000-0000-0000-0000-0000000000aa/v2.0"));
+
+            var provider = new TokenValidationParametersProvider(configuration, this.logger);
+            var tvp = ReadParameters(provider);
+
+            Assert.That(tvp.IssuerValidator, Is.Null, "no custom issuer validator when the allowlist is empty — the default ValidIssuers path is preserved.");
+        }
+
+        private static TokenValidationParameters ReadParameters(TokenValidationParametersProvider provider)
+        {
+            var field = typeof(TokenValidationParametersProvider).GetField(
+                "tokenValidationParameters",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.That(field, Is.Not.Null, "Expected private field tokenValidationParameters.");
+            return (TokenValidationParameters)field!.GetValue(provider)!;
         }
 
         private static IConfiguration BuildConfiguration(params (string key, string value)[] entries)

--- a/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
+++ b/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
@@ -1,0 +1,209 @@
+# S2S cross-tenant access + application access-picker — design
+
+Date: 2026-06-28
+Status: Approved (brainstormed with the owner)
+Repos: `safeexchange` (backend, Azure Functions) and `safeexchange.blazorpwa` (Blazor WASM PWA + AdminPanel)
+Branch (both repos): `feature/s2s-cross-tenant-and-picker`
+
+## Problem
+
+A SafeExchange instance is configured to accept **user** tokens from a single
+"home" tenant (the customers/consumers tenant). A user from that tenant wants to
+run a **headless daemon** that authenticates to SafeExchange programmatically as
+a registered **S2S application**.
+
+Two things block this today:
+
+1. **Token validation is single-tenant.** `DefaultAuthenticationMiddleware`
+   validates every JWT against a single static `TokenValidationParameters` built
+   from `Authentication:ValidIssuers` + `MetadataAddress`, both pinned to one
+   tenant. A daemon token issued by the developer's **own** tenant fails issuer
+   validation (`401`, IDX10205) *before* the `(clientId, tenantId)` DB
+   registration in `TokenMiddlewareCore` is ever consulted. The personal/consumers
+   authority cannot mint client-credentials tokens at all, so a daemon **must**
+   use a real org tenant — which the instance currently rejects.
+
+2. **The registration UI cannot set a tenant.** `RegisterS2SApp.razor` collects
+   only display name + client id; the backend self-service endpoint already
+   accepts an optional `AadTenantId` but the form never sends one, so the app is
+   silently registered under the caller's sign-in tenant.
+
+Separately, when a user grants a secret's access to an application, the access
+editor offers a **dropdown** of all registered apps. The owner wants this to be a
+**search modal** (magnifying-glass icon) like the user/group pickers, searchable
+by name with client/tenant id shown for disambiguation.
+
+## Decision (owner's steer)
+
+- **Do NOT widen issuer trust to all tenants.** Keep user-token validation pinned
+  to the configured home tenant. Add a **fixed, configuration-time allowlist of
+  tenants from which app-only (S2S) tokens are accepted**. The registration UI
+  lets the user pick a tenant **from that list only** — never an arbitrary tenant.
+- **Replace the application dropdown with a search modal** backed by a new search
+  endpoint; all users can pick any previously-registered app by name.
+
+## Non-goals
+
+- No change to how user tokens are validated (home tenant only — unchanged).
+- No Microsoft Graph lookup for applications; application search is over the
+  locally-registered `Applications` only.
+- No automatic Entra app provisioning — operators do the Entra setup (below).
+
+## Backend design (`safeexchange`)
+
+### 1. S2S tenant allowlist configuration
+
+New property on `AuthenticationConfiguration` (`Authentication` config section):
+
+```
+Authentication:S2SAllowedTenants   (string, JSON array; default "" = feature off)
+```
+
+Value is a JSON array of `{ "tenantId": "<guid>", "displayName": "<label>" }`.
+Stored as a single Key Vault secret `Authentication--S2SAllowedTenants` so it
+fits the existing flat-settings deployment model. A pure, unit-tested parser
+(`S2SAllowedTenant.ParseList`) turns it into `IReadOnlyList<S2SAllowedTenant>`;
+malformed entries are skipped with a warning, non-GUID tenant ids rejected.
+
+`displayName` defaults to the tenant id when absent. Empty / missing config ⇒
+empty list ⇒ **feature is off and behavior is byte-for-byte identical to today**.
+
+### 2. Token-kind-aware issuer validation
+
+In `TokenValidationParametersProvider`:
+
+- Keep `ValidateIssuer = true`, `ValidAudiences`, lifetime, signed-token,
+  algorithm allowlist — unchanged.
+- When the allowlist is **empty**: keep the current behavior exactly, including
+  `EnableAadSigningKeyIssuerValidation()`. Zero regression for existing
+  instances (regular-tenant or customers-tenant) that don't use the feature.
+- When the allowlist is **non-empty**: install a custom `IssuerValidator`
+  delegate:
+  - **User tokens** (delegated; carry `scp`/`scope`): issuer must be one of the
+    configured `ValidIssuers` (home tenant) — unchanged restriction.
+  - **App-only tokens** (client-credentials; carry `appid`+`appidacr` or
+    `azp`+`azpacr`, no scope): issuer accepted if it is a configured issuer **or**
+    one derived from an allowlisted tenant — i.e. `https://login.microsoftonline.com/{tid}/v2.0`
+    or `https://sts.windows.net/{tid}/`.
+  - Otherwise → `SecurityTokenInvalidIssuerException` (surfaced as the generic
+    `401`, never echoing IDX text — existing CWE-209 hardening preserved).
+
+Token kind is classified by a shared, unit-tested helper
+(`TokenClassification.IsAppOnlyToken`) that `TokenHelper` is refactored to use
+too, so the auth layer and the validator can't drift.
+
+**Signing keys / security rationale.** Azure AD signs every worldwide-cloud
+tenant's tokens with the same published key set, and the `iss`/`tid` claims are
+themselves signed (tamper-proof). The existing `MetadataAddress` keys therefore
+validate the *signature* of an allowlisted-tenant token; the **signed issuer
+allowlist is the tenant gate**. `EnableAadSigningKeyIssuerValidation()` binds the
+key to the single configured issuer and would reject allowlisted tenants, so it
+is not applied when the allowlist is in use; its protection (relevant only to
+`common`/multi-tenant apps that trust tenant-supplied keys) is not meaningful for
+Microsoft-managed worldwide keys under a strict signed-issuer allowlist. Audience
+validation and the `(clientId, tenantId)` DB-registration gate remain in force as
+defense in depth. This trade-off is called out explicitly for security review.
+
+### 3. Allowed-tenants endpoint (for the registration UI)
+
+`GET /v2/s2sapps/allowed-tenants` — authenticated user; gated by
+`Features.S2SAppsSelfService` like the other `s2sapps` routes. Returns the
+`{ tenantId, displayName }` list (empty when the feature is off, so the UI can
+hide/disable the tenant control). Reads the parsed allowlist via
+`IOptionsMonitor<AuthenticationConfiguration>` (newly registered in DI).
+
+### 4. Tenant-constrained registration
+
+In `SafeExchangeS2SApps.RunRegister`:
+
+- When the allowlist is **non-empty**: the resolved `AadTenantId` must be a
+  member of the allowlist; otherwise `400` with a clear message. (The UI only
+  offers allowlisted tenants; this is the server-side enforcement.)
+- When the allowlist is **empty**: unchanged (defaults to caller's home tenant).
+
+The admin path (`POST /v2/applications/{id}`) is left flexible; the issuer
+allowlist remains the hard security boundary (an app registered for a
+non-allowlisted tenant simply can't authenticate).
+
+### 5. Application search endpoint
+
+`POST /v2/application-search` — mirrors `user-search`/`group-search`:
+
+- Authenticated **users only** (applications get `403`, like the other searches).
+- Body `SearchInput { searchString }`, validated by `SearchStringValidator`.
+- Searches **locally registered, enabled** `Applications` by `DisplayName`
+  (case-insensitive contains), capped (e.g. 50) and ordered by name.
+- Returns `List<ApplicationSearchOutput { DisplayName, AadClientId, AadTenantId }>`
+  so the picker can disambiguate multi-tenant apps.
+- Always available (no Graph feature flag — it reads the local DB).
+
+`GET /v2/applications-list` stays for backward compatibility.
+
+## Frontend design (`safeexchange.blazorpwa`)
+
+### 6. Tenant dropdown in `RegisterS2SApp.razor`
+
+- On init, call new `ApiClient.GetS2SAllowedTenantsAsync()` → `GET /v2/s2sapps/allowed-tenants`.
+- If the list is non-empty, render a required `<select>` of `{ displayName }`
+  (value = tenantId); preselect when there is exactly one. Bind the choice into
+  `S2SAppRegistrationRequest.AadTenantId` (the DTO already has the slot).
+- If empty (feature off), hide the control and behave as today (server defaults
+  to home tenant).
+
+### 7. Application search picker in `CreateData.razor` / `EditData.razor`
+
+- Replace the application-row `<InputSelect>` (bound to
+  `StateContainer.RegisteredApplications`) with a read-only `InputText` +
+  magnifying-glass button, mirroring the user/group rows.
+- Add an `ItemSearchDialog<Application>` instance with an `ItemTemplate` showing
+  `DisplayName` and, as secondary text, the client/tenant id.
+- New `ApiClient.SearchApplicationsAsync(SearchInput)` → `POST /v2/application-search`.
+- `Start…`/`Finish…` callbacks mirror the user/group ones; on pick, write the
+  app's `DisplayName` into both `SubjectName` and `SubjectId` (the access grant
+  keys on the globally-unique DisplayName, matching current server behavior).
+
+## Entra prerequisites (operator / owner, not code)
+
+For a daemon in the developer's own tenant to obtain a SafeExchange-audience
+token cross-tenant:
+
+1. The **SafeExchange API app registration must be multi-tenant**, so its service
+   principal can be provisioned (admin-consented) into the developer's tenant.
+2. It must **expose an app role** (e.g. `Access.AsApplication`) that is assigned
+   to the daemon app — Azure won't mint a `.default` app token for the SafeExchange
+   audience without at least one app-role assignment (SafeExchange itself only
+   checks the `(clientId, tenantId)` registration, not the role).
+3. The developer admin-consents both in their **own** tenant (where they are the
+   admin — this is why "no admin in the customers tenant" is no longer a blocker).
+
+## Backward compatibility
+
+- `Authentication:S2SAllowedTenants` empty ⇒ no new behavior anywhere; user-token
+  and existing app-token validation byte-for-byte unchanged; registration and the
+  app dropdown keep working. Regular-tenant instances are unaffected until an
+  operator opts in by populating the allowlist.
+
+## Testing strategy (red-green TDD)
+
+- `S2SAllowedTenant.ParseList`: valid JSON, empty/missing, malformed entries,
+  non-GUID tenant ids, display-name default.
+- `TokenClassification.IsAppOnlyToken`: v1 (appid/appidacr), v2 (azp/azpacr),
+  delegated-with-scope, mixed — and a test asserting `TokenHelper` agrees.
+- Issuer validation: empty allowlist ⇒ params identical to today (incl.
+  `EnableAadSigningKeyIssuerValidation`); non-empty ⇒ user token from an
+  allowlisted (non-home) tenant rejected, app token from an allowlisted tenant
+  accepted, app token from a non-allowlisted tenant rejected, home-tenant tokens
+  always accepted.
+- Registration: allowlisted tenant accepted; non-allowlisted rejected `400`;
+  empty allowlist ⇒ legacy default-to-home behavior.
+- `application-search`: forbids application callers; validates search string;
+  returns only enabled apps; disambiguation fields populated.
+- Frontend: build + targeted component checks where feasible.
+
+## Deployment / rollout
+
+1. Merge backend PR first (frontend depends on the new endpoints).
+2. Set `Authentication--S2SAllowedTenants` in the target Key Vault to the JSON
+   allowlist (staging: include tenant `1472703e-99d8-45ee-aeac-7ec3ae9ab104`).
+3. Ensure `Features:S2SAppsSelfService` is enabled for self-service registration.
+4. Complete the Entra prerequisites above for the daemon's tenant.

--- a/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
+++ b/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
@@ -106,7 +106,7 @@ defense in depth. This trade-off is called out explicitly for security review.
 
 ### 3. Allowed-tenants endpoint (for the registration UI)
 
-`GET /v2/s2sapps/allowed-tenants` — authenticated user; gated by
+`GET /v2/s2sapps-allowed-tenants` — authenticated user; gated by
 `Features.S2SAppsSelfService` like the other `s2sapps` routes. Returns the
 `{ tenantId, displayName }` list (empty when the feature is off, so the UI can
 hide/disable the tenant control). Reads the parsed allowlist via
@@ -143,7 +143,7 @@ non-allowlisted tenant simply can't authenticate).
 
 ### 6. Tenant dropdown in `RegisterS2SApp.razor`
 
-- On init, call new `ApiClient.GetS2SAllowedTenantsAsync()` → `GET /v2/s2sapps/allowed-tenants`.
+- On init, call new `ApiClient.GetS2SAllowedTenantsAsync()` → `GET /v2/s2sapps-allowed-tenants`.
 - If the list is non-empty, render a required `<select>` of `{ displayName }`
   (value = tenantId); preselect when there is exactly one. Bind the choice into
   `S2SAppRegistrationRequest.AadTenantId` (the DTO already has the slot).


### PR DESCRIPTION
## Summary

Lets a user from the configured (customers/consumers) tenant run a **headless daemon** that authenticates to SafeExchange as an S2S application using **their own Entra tenant**, and makes registered applications **searchable** in the secret access-list picker.

Design spec: `docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md`. Frontend companion PR: yury-opolev/safeexchange.blazorpwa#<frontend-pr>.

## What changed

1. **Token-kind-aware issuer validation** (`TokenValidationParametersProvider` + `S2SIssuerValidator` + `TokenClassification`). New config `Authentication:S2SAllowedTenants` (JSON list of `{tenantId, displayName}`). When non-empty, **app-only** (client-credentials) tokens are accepted from the home tenant **or** any allowlisted tenant; **user** tokens stay restricted to the home tenant. When empty → **byte-for-byte unchanged** (existing `EnableAadSigningKeyIssuerValidation` preserved). `TokenHelper` is refactored to reuse `TokenClassification` so the auth path and the validator can't drift.
2. **`GET /v2/s2sapps-allowed-tenants`** — surfaces the allowlist to the registration UI (gated by `Features:S2SAppsSelfService`).
3. **Tenant-constrained registration** — self-service registration rejects an `AadTenantId` not in the allowlist (when configured); empty allowlist keeps the legacy home-tenant default.
4. **`POST /v2/application-search`** — mirrors user/group search (user callers only, validated `SearchInput`), searches locally-registered enabled apps by display name, returns `DisplayName + AadClientId + AadTenantId`.

## Security model

The signed `iss` claim + the fixed allowlist is the tenant gate; signature (global commercial-cloud AAD keys), audience, and the `(clientId, tenantId)` registration check remain in force. `EnableAadSigningKeyIssuerValidation()` binds the key to a single configured issuer and is therefore not applied when the allowlist is in use — its protection is only meaningful for `common` multi-tenant apps trusting tenant-supplied keys, not Microsoft-managed worldwide keys under a strict signed-issuer allowlist. Reviewed adversarially (no critical/high findings).

## Entra prerequisites (operational)

For a daemon in your own tenant to obtain a SafeExchange-audience token cross-tenant: the SafeExchange **API app registration must be multi-tenant**, **expose an app role** (e.g. `Access.AsApplication`) assigned to the daemon app, and be **admin-consented in your own tenant** (where you are the admin).

## Testing

Red-green TDD. New unit tests: allowlist parser (fail-closed), token classification, `S2SIssuerValidator`, the provider issuer-validator wiring, the registration allowlist boundary, and the application-search handler. All InMemory/pure tests pass (the suite's Cosmos-emulator fixtures require a local emulator and are unaffected by this change).

## Deploy (staging)

Set Key Vault secret `Authentication--S2SAllowedTenants` to the JSON allowlist (include tenant `1472703e-99d8-45ee-aeac-7ec3ae9ab104`) and ensure `Features:S2SAppsSelfService` is enabled. Empty allowlist = feature off, so regular-tenant instances are unaffected.