### PR TITLE
fix(s2s): log malformed allowlist config; bound application-search scan

### DIFF
--- a/SafeExchange.Core/Functions/SafeExchangeApplicationSearch.cs
+++ b/SafeExchange.Core/Functions/SafeExchangeApplicationSearch.cs
@@ -28,6 +28,12 @@ namespace SafeExchange.Core.Functions
         /// <summary>Upper bound on returned hits — the picker is for narrowing by name, not bulk listing.</summary>
         public const int MaxResults = 50;
 
+        /// <summary>
+        /// Upper bound on rows the candidate scan may materialize before the in-memory order/cap.
+        /// Bounds worst-case RU/latency for a very short/broad term; must be &gt;= <see cref="MaxResults"/>.
+        /// </summary>
+        internal const int ScanCap = 500;
+
         private readonly SafeExchangeDbContext dbContext;
 
         private readonly ITokenHelper tokenHelper;
@@ -92,12 +98,7 @@ namespace SafeExchange.Core.Functions
 
                 var term = searchInput.SearchString.Trim().ToLower();
 
-                // Filter server-side (enabled + name match), then order/cap in memory to
-                // avoid Cosmos composite-index requirements for OrderBy. The name match
-                // mirrors the admin application search.
-                var matches = await this.dbContext.Applications
-                    .Where(a => a.Enabled && a.DisplayName.ToLower().Contains(term))
-                    .ToListAsync();
+                var matches = await this.ScanMatchingApplicationsAsync(term);
 
                 var results = matches
                     .OrderBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)
@@ -114,6 +115,17 @@ namespace SafeExchange.Core.Functions
                     request, HttpStatusCode.OK,
                     new BaseResponseObject<List<ApplicationSearchOutput>> { Status = "ok", Result = results });
             }, nameof(HandleSearchApplication), log);
+
+        /// <summary>
+        /// Server-side candidate scan: enabled applications whose display name contains the
+        /// (already trimmed/lowercased) <paramref name="term"/>. Filtered server-side to avoid a
+        /// Cosmos composite index for OrderBy; the caller orders and caps the result in memory.
+        /// </summary>
+        internal async Task<List<Application>> ScanMatchingApplicationsAsync(string term)
+            => await this.dbContext.Applications
+                .Where(a => a.Enabled && a.DisplayName.ToLower().Contains(term))
+                .Take(ScanCap)
+                .ToListAsync();
 
         private async Task<SearchInput?> TryGetSearchInputAsync(HttpRequestData request, ILogger log)
         {

--- a/SafeExchange.Core/Functions/SafeExchangeS2SApps.cs
+++ b/SafeExchange.Core/Functions/SafeExchangeS2SApps.cs
@@ -139,7 +139,7 @@ namespace SafeExchange.Core.Functions
                 // restricted to those tenants — an app registered for a tenant we don't accept
                 // app tokens from could never authenticate. An empty allowlist (feature off)
                 // keeps the legacy behavior (any tenant, defaulting to the caller's home tenant).
-                var allowedTenants = S2SAllowedTenant.ParseList(this.authConfig.CurrentValue.S2SAllowedTenants);
+                var allowedTenants = S2SAllowedTenant.ParseList(this.authConfig.CurrentValue.S2SAllowedTenants, log);
                 if (allowedTenants.Count > 0 && !S2SAllowedTenant.Contains(allowedTenants, tenantId))
                 {
                     return await BadRequestAsync(request, "The selected tenant is not in the configured list of tenants allowed for S2S applications.");
@@ -295,7 +295,7 @@ namespace SafeExchange.Core.Functions
 
             return await ActionResults.TryCatchAsync(request, async () =>
             {
-                var allowed = S2SAllowedTenant.ParseList(this.authConfig.CurrentValue.S2SAllowedTenants);
+                var allowed = S2SAllowedTenant.ParseList(this.authConfig.CurrentValue.S2SAllowedTenants, log);
                 var dto = allowed
                     .Select(t => new S2SAllowedTenantOutput { TenantId = t.TenantId, DisplayName = t.DisplayName })
                     .ToList();

--- a/SafeExchange.Tests/Tests/ApplicationSearchScanCapTests.cs
+++ b/SafeExchange.Tests/Tests/ApplicationSearchScanCapTests.cs
@@ -1,0 +1,85 @@
+/// <summary>
+/// ApplicationSearchScanCapTests — guards the server-side bound on POST /v2/application-search.
+/// The endpoint orders and caps results in memory (to avoid a Cosmos composite index for
+/// OrderBy), so the DB scan itself must be bounded — otherwise a very short/broad term pulls
+/// the entire matching set into memory. The candidate scan must never materialize more than
+/// ScanCap rows regardless of how many applications match.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using NUnit.Framework;
+    using SafeExchange.Core;
+    using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Filters;
+    using SafeExchange.Core.Functions;
+    using SafeExchange.Core.Model;
+    using SafeExchange.Tests.Utilities;
+    using System;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class ApplicationSearchScanCapTests
+    {
+        private SafeExchangeDbContext dbContext = null!;
+        private SafeExchangeApplicationSearch handler = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var dbContextOptions = new DbContextOptionsBuilder<SafeExchangeDbContext>()
+                .UseInMemoryDatabase($"{nameof(ApplicationSearchScanCapTests)}-{Guid.NewGuid()}")
+                .Options;
+            this.dbContext = new SafeExchangeDbContext(dbContextOptions);
+
+            var tokenHelper = new TestTokenHelper();
+            var groups = Mock.Of<IOptionsMonitor<GloballyAllowedGroupsConfiguration>>(
+                x => x.CurrentValue == new GloballyAllowedGroupsConfiguration());
+            var admin = Mock.Of<IOptionsMonitor<AdminConfiguration>>(
+                x => x.CurrentValue == new AdminConfiguration());
+            var globalFilters = new GlobalFilters(groups, admin, tokenHelper, TestFactory.CreateLogger<GlobalFilters>());
+            this.handler = new SafeExchangeApplicationSearch(this.dbContext, tokenHelper, globalFilters);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            this.dbContext.Database.EnsureDeleted();
+            this.dbContext.Dispose();
+        }
+
+        [Test]
+        public async Task Candidate_scan_is_bounded_by_ScanCap_even_when_more_match()
+        {
+            // Seed comfortably more enabled, name-matching apps than the scan cap.
+            var total = SafeExchangeApplicationSearch.ScanCap + 50;
+            for (var i = 0; i < total; i++)
+            {
+                this.dbContext.Applications.Add(new Application
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    PartitionKey = Application.DefaultPartitionKey,
+                    DisplayName = $"MatchingApp{i:D4}",
+                    AadTenantId = "11111111-1111-1111-1111-111111111111",
+                    AadClientId = Guid.NewGuid().ToString(),
+                    ContactEmail = "owner@test.test",
+                    Enabled = true,
+                    CreatedBy = "User owner@test.test",
+                    ModifiedBy = string.Empty,
+                });
+            }
+
+            await this.dbContext.SaveChangesAsync();
+
+            // "matchingapp" (lowercased, as RunSearch normalizes) matches every seeded app.
+            var scanned = await this.handler.ScanMatchingApplicationsAsync("matchingapp");
+
+            Assert.That(scanned.Count, Is.EqualTo(SafeExchangeApplicationSearch.ScanCap),
+                "the DB scan must be capped server-side, not materialize the whole matching set");
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/S2SAllowedTenantsLoggingTests.cs
+++ b/SafeExchange.Tests/Tests/S2SAllowedTenantsLoggingTests.cs
@@ -1,0 +1,146 @@
+/// <summary>
+/// S2SAllowedTenantsLoggingTests — regression tests for the observability of a
+/// misconfigured Authentication:S2SAllowedTenants value. Parsing fails closed (empty
+/// list, no S2S tenants trusted) which is correct security behavior, but "silently
+/// off" is hard to diagnose. Both handlers that parse the allowlist must pass their
+/// ILogger through so a malformed value leaves a trace instead of vanishing.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Azure.Core.Serialization;
+    using Microsoft.Azure.Functions.Worker;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using NUnit.Framework;
+    using SafeExchange.Core;
+    using SafeExchange.Core.Applications;
+    using SafeExchange.Core.Configuration;
+    using SafeExchange.Core.Filters;
+    using SafeExchange.Core.Functions;
+    using SafeExchange.Core.Model;
+    using SafeExchange.Core.Model.Dto.Input;
+    using SafeExchange.Tests.Utilities;
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class S2SAllowedTenantsLoggingTests
+    {
+        private const string HomeTenant = "00000000-0000-0000-0000-000000000001";
+        private const string SomeClientId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        // A value that is syntactically not a JSON array, so ParseList fails closed and
+        // (with a logger) emits an error naming the offending setting.
+        private const string MalformedAllowlist = "not json at all";
+
+        private SafeExchangeDbContext dbContext = null!;
+        private ITokenHelper tokenHelper = null!;
+        private GlobalFilters globalFilters = null!;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            this.tokenHelper = new TestTokenHelper();
+
+            var groups = Mock.Of<IOptionsMonitor<GloballyAllowedGroupsConfiguration>>(
+                x => x.CurrentValue == new GloballyAllowedGroupsConfiguration());
+            var admin = Mock.Of<IOptionsMonitor<AdminConfiguration>>(
+                x => x.CurrentValue == new AdminConfiguration());
+            this.globalFilters = new GlobalFilters(groups, admin, this.tokenHelper, TestFactory.CreateLogger<GlobalFilters>());
+
+            var workerOptions = Options.Create(new WorkerOptions() { Serializer = new JsonObjectSerializer() });
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            serviceProviderMock.Setup(x => x.GetService(typeof(IOptions<WorkerOptions>))).Returns(workerOptions);
+            TestFactory.FunctionContext.InstanceServices = serviceProviderMock.Object;
+
+            DateTimeProvider.SpecifiedDateTime = DateTime.UtcNow;
+            DateTimeProvider.UseSpecifiedDateTime = true;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeCleanup() => DateTimeProvider.UseSpecifiedDateTime = false;
+
+        [SetUp]
+        public void Setup()
+        {
+            var dbContextOptions = new DbContextOptionsBuilder<SafeExchangeDbContext>()
+                .UseInMemoryDatabase($"{nameof(S2SAllowedTenantsLoggingTests)}-{Guid.NewGuid()}")
+                .Options;
+            this.dbContext = new SafeExchangeDbContext(dbContextOptions);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            this.dbContext.Database.EnsureDeleted();
+            this.dbContext.Dispose();
+        }
+
+        private SafeExchangeS2SApps CreateHandler(string s2sAllowedTenantsJson)
+        {
+            var features = Mock.Of<IOptionsMonitor<Features>>(x => x.CurrentValue == new Features { S2SAppsSelfService = true });
+            var limits = Mock.Of<IOptionsMonitor<Limits>>(x => x.CurrentValue == new Limits());
+            var authConfig = Mock.Of<IOptionsMonitor<AuthenticationConfiguration>>(
+                x => x.CurrentValue == new AuthenticationConfiguration { S2SAllowedTenants = s2sAllowedTenantsJson });
+            var ownerService = new ApplicationOwnerService(this.dbContext);
+            return new SafeExchangeS2SApps(this.dbContext, this.tokenHelper, this.globalFilters, ownerService, features, limits, authConfig);
+        }
+
+        private static ClaimsPrincipal Caller()
+            => new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim("upn", "registrar@test.test"),
+                new Claim("oid", "00000000-0000-0000-0000-0000000000d1"),
+                new Claim("tid", HomeTenant),
+            }));
+
+        [Test]
+        public async Task AllowedTenants_endpoint_logs_error_on_malformed_config()
+        {
+            var handler = this.CreateHandler(MalformedAllowlist);
+            var recording = new RecordingLogger();
+
+            var request = TestFactory.CreateHttpRequestData("get");
+            var response = await handler.RunListAllowedTenants(request, Caller(), recording) as TestHttpResponseData;
+
+            // Fails closed to an empty list — the endpoint still succeeds ...
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            // ... but the misconfiguration must leave a diagnostic trace naming the setting.
+            Assert.That(recording.Has(LogLevel.Error, "S2SAllowedTenants"), Is.True,
+                "malformed S2SAllowedTenants must be logged so an operator can diagnose the empty picker");
+        }
+
+        [Test]
+        public async Task Register_logs_error_on_malformed_config()
+        {
+            var handler = this.CreateHandler(MalformedAllowlist);
+            var recording = new RecordingLogger();
+
+            var request = TestFactory.CreateHttpRequestData("post");
+            request.SetBodyAsJson(new S2SAppRegistrationInput
+            {
+                DisplayName = "MyDaemonApp",
+                AadClientId = SomeClientId,
+                AadTenantId = null, // defaults to the caller's home tenant under a fail-closed (empty) allowlist
+                AdditionalOwners = new List<S2SAppOwnerInput>
+                {
+                    new S2SAppOwnerInput { SubjectType = OwnerSubjectType.User, SubjectId = "coowner@test.test", SubjectName = "Co Owner" },
+                },
+            });
+
+            var response = await handler.RunRegister(request, Caller(), recording) as TestHttpResponseData;
+
+            // Malformed allowlist parses as empty -> legacy home-tenant default -> registration succeeds ...
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+            // ... but silently disabling the tenant restriction must be traceable.
+            Assert.That(recording.Has(LogLevel.Error, "S2SAllowedTenants"), Is.True,
+                "malformed S2SAllowedTenants must be logged on the registration path too");
+        }
+    }
+}

--- a/SafeExchange.Tests/Utilities/RecordingLogger.cs
+++ b/SafeExchange.Tests/Utilities/RecordingLogger.cs
@@ -1,0 +1,39 @@
+/// <summary>
+/// RecordingLogger — a test ILogger that captures every log entry (level, formatted
+/// message, exception) so tests can assert that a diagnostic was actually emitted.
+/// Used to verify observability fixes, e.g. that a call site passes a logger through
+/// so a malformed config produces a trace instead of failing silently.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public sealed class RecordingLogger : ILogger
+    {
+        public sealed record Entry(LogLevel Level, string Message, Exception? Exception);
+
+        public List<Entry> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel,
+                                EventId eventId,
+                                TState state,
+                                Exception exception,
+                                Func<TState, Exception, string> formatter)
+        {
+            this.Entries.Add(new Entry(logLevel, formatter(state, exception), exception));
+        }
+
+        /// <summary>True if any recorded entry at the given level contains the substring.</summary>
+        public bool Has(LogLevel level, string containing)
+            => this.Entries.Any(e => e.Level == level
+                && e.Message.Contains(containing, StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
Two low-severity upstream follow-ups to the S2S cross-tenant + picker work (#58), from a self-review note. One PR, two items.

## 1. `ParseList` called without a logger (observability)
`SafeExchangeS2SApps` called `S2SAllowedTenant.ParseList(...)` at both the register (~L142) and allowed-tenants (~L298) call sites **without** the `ILogger`. `ParseList` fails closed (empty list → S2S tenant restriction silently off) and only emits diagnostics when a logger is supplied — so a fat-fingered `Authentication:S2SAllowedTenants` disabled the restriction/picker with **no App Insights trace**. Now both pass `log` through. (The startup path in `TokenValidationParametersProvider` already logged.)

## 2. `application-search` materialized all matches before capping (perf)
`SafeExchangeApplicationSearch` did `.Where(enabled && name-match).ToListAsync()` then ordered + `Take(MaxResults)` **in memory** — unbounded by design (in-memory OrderBy avoids a Cosmos composite index). Extracted the candidate scan into `ScanMatchingApplicationsAsync` and bounded it server-side with `Take(ScanCap=500)`, so a very short/broad term can't pull the whole `Applications` set into memory. Ordering after the cap is approximate, which is acceptable for a name-search picker.

## Tests (EF InMemory, written TDD red-green)
- `RecordingLogger` test util; `S2SAllowedTenantsLoggingTests` — both handlers log an error on malformed config (watched fail before the fix).
- `ApplicationSearchScanCapTests` — the scan caps at `ScanCap` when more apps match (watched fail at 550 vs 500 before the fix).

**Verification:** full blast radius (all S2S / application-search / config / validator fixtures) — **104/104 green**. The repo's Cosmos-emulator integration tests were not run (emulator not available in this environment); no integration-backed code paths were changed.