### PR TITLE
Add v3 API surface; freeze v2 for backward compatibility + version telemetry

### DIFF
--- a/SafeExchange.Core/Functions/SafeExchangeAccess.cs
+++ b/SafeExchange.Core/Functions/SafeExchangeAccess.cs
@@ -62,7 +62,7 @@ namespace SafeExchange.Core.Functions
 
         public async Task<HttpResponseData> Run(
             HttpRequestData request,
-            string secretId, ClaimsPrincipal principal, ILogger log)
+            string secretId, ClaimsPrincipal principal, ILogger log, bool enrichedAccessList = false)
         {
             var (shouldReturn, filterResponse) = await this.globalFilters.GetFilterResultAsync(request, principal, this.dbContext);
             if (shouldReturn)
@@ -113,7 +113,9 @@ namespace SafeExchange.Core.Functions
                                 ActionResults.InsufficientPermissions(PermissionType.Read, secretId, consentRequired ? GraphDataProvider.ConsentRequiredSubStatus : string.Empty));
                         }
 
-                        return await this.GetAccessListAsync(request, existingMetadata.ObjectName, subjectType, subjectId, log);
+                        return enrichedAccessList
+                            ? await this.GetEnrichedAccessListAsync(request, existingMetadata.ObjectName, subjectType, subjectId, log)
+                            : await this.GetAccessListAsync(request, existingMetadata.ObjectName, log);
                     }
 
                 case "delete":
@@ -340,7 +342,21 @@ namespace SafeExchange.Core.Functions
             await this.permissionsManager.SetPermissionAsync(SubjectType.Group, existingGroup.GroupId, existingGroup.DisplayName, secretId, permission);
         }
 
-        private async Task<HttpResponseData> GetAccessListAsync(HttpRequestData request, string secretId, SubjectType subjectType, string subjectId, ILogger log)
+        private async Task<HttpResponseData> GetAccessListAsync(HttpRequestData request, string secretId, ILogger log)
+            => await ActionResults.TryCatchAsync(request, async () =>
+        {
+            var existingPermissions = await this.dbContext.Permissions.Where(p => p.SecretName.Equals(secretId)).ToListAsync();
+
+            return await ActionResults.CreateResponseAsync(
+                request, HttpStatusCode.OK,
+                new BaseResponseObject<List<SubjectPermissionsOutput>>
+                {
+                    Status = "ok",
+                    Result = existingPermissions.Select(p => p.ToDto()).ToList()
+                });
+        }, nameof(GetAccessListAsync), log);
+
+        private async Task<HttpResponseData> GetEnrichedAccessListAsync(HttpRequestData request, string secretId, SubjectType subjectType, string subjectId, ILogger log)
             => await ActionResults.TryCatchAsync(request, async () =>
         {
             var existingPermissions = await this.dbContext.Permissions.Where(p => p.SecretName.Equals(secretId)).ToListAsync();
@@ -357,7 +373,7 @@ namespace SafeExchange.Core.Functions
                         CallerEffectivePermissions = EffectivePermissionsOutput.FromPermissionType(effective)
                     }
                 });
-        }, nameof(GetAccessListAsync), log);
+        }, nameof(GetEnrichedAccessListAsync), log);
 
         private async Task<HttpResponseData> RevokeAccessAsync(ObjectMetadata secret, HttpRequestData request, SubjectType actorType, string actorId, ILogger log)
             => await ActionResults.TryCatchAsync(request, async () =>

--- a/SafeExchange.Core/Functions/SafeExchangeSecretMeta.cs
+++ b/SafeExchange.Core/Functions/SafeExchangeSecretMeta.cs
@@ -130,17 +130,80 @@ namespace SafeExchange.Core.Functions
             }
         }
 
+        public async Task<HttpResponseData> RunListV3(
+            HttpRequestData request, ClaimsPrincipal principal, ILogger log)
+        {
+            var (shouldReturn, filterResult) = await this.globalFilters.GetFilterResultAsync(request, principal, this.dbContext);
+            if (shouldReturn)
+            {
+                return filterResult ?? request.CreateResponse(HttpStatusCode.NoContent);
+            }
+
+            (SubjectType subjectType, string subjectId) = await SubjectHelper.GetSubjectInfoAsync(this.tokenHelper, principal, this.dbContext);
+            if (SubjectType.Application.Equals(subjectType) && string.IsNullOrEmpty(subjectId))
+            {
+                return await ActionResults.ForbiddenAsync(request, "Application is not registered or disabled.");
+            }
+
+            log.LogInformation($"{nameof(SafeExchangeSecretMeta)}-{nameof(RunListV3)} triggered by {subjectType} (tid {TelemetryContext.Current}) [{request.Method}].");
+
+            switch (request.Method.ToLower())
+            {
+                case "get":
+                    return await this.HandleListSecretMetaV3(request, subjectType, subjectId, log);
+
+                default:
+                    return await ActionResults.CreateResponseAsync(
+                        request, HttpStatusCode.BadRequest,
+                        new BaseResponseObject<object> { Status = "error", Error = "Request method not recognized" });
+            }
+        }
+
         private async Task<HttpResponseData> HandleListSecretMeta(HttpRequestData request, SubjectType subjectType, string subjectId, ILogger log)
             => await ActionResults.TryCatchAsync(request, async () =>
         {
-            var rawTags = Array.Empty<string>();
-            var query = request.Url?.Query;
-            if (!string.IsNullOrEmpty(query))
+            var (tagsOk, requiredTags, tagsError) = TryGetRequiredTags(request);
+            if (!tagsOk)
             {
-                rawTags = System.Web.HttpUtility.ParseQueryString(query).GetValues("tag") ?? Array.Empty<string>();
+                log.LogInformation($"Invalid tag filter: {tagsError}.");
+                return await ActionResults.CreateResponseAsync(
+                    request, HttpStatusCode.BadRequest,
+                    new BaseResponseObject<object> { Status = "bad_request", Error = tagsError });
             }
 
-            var (tagsOk, requiredTags, tagsError) = TagValidator.TryNormalizeList(rawTags);
+            var permissions = await this.dbContext.Permissions
+                .Where(p => p.SubjectType.Equals(subjectType) && p.SubjectId.Equals(subjectId) && p.CanRead)
+                .ToListAsync();
+
+            var names = permissions.Select(p => p.SecretName).Distinct().ToList();
+            var tagMap = await this.LoadTagMapAsync(names, requiredTags);
+
+            if (requiredTags.Count > 0)
+            {
+                var matched = new HashSet<string>(tagMap.Keys);
+                permissions = permissions.Where(p => matched.Contains(p.SecretName)).ToList();
+            }
+
+            var dtos = permissions.Select(p =>
+            {
+                var dto = p.ToDto();
+                dto.Tags = tagMap.TryGetValue(p.SecretName, out var t) ? t.ToList() : new List<string>();
+                return dto;
+            }).ToList();
+
+            return await ActionResults.CreateResponseAsync(
+                request, HttpStatusCode.OK,
+                new BaseResponseObject<List<SubjectPermissionsOutput>>
+                {
+                    Status = "ok",
+                    Result = dtos
+                });
+        }, nameof(HandleListSecretMeta), log);
+
+        private async Task<HttpResponseData> HandleListSecretMetaV3(HttpRequestData request, SubjectType subjectType, string subjectId, ILogger log)
+            => await ActionResults.TryCatchAsync(request, async () =>
+        {
+            var (tagsOk, requiredTags, tagsError) = TryGetRequiredTags(request);
             if (!tagsOk)
             {
                 log.LogInformation($"Invalid tag filter: {tagsError}.");
@@ -152,27 +215,7 @@ namespace SafeExchange.Core.Functions
             var readableSecrets = await this.permissionsManager.GetReadableSecretsAsync(subjectType, subjectId);
 
             var names = readableSecrets.Select(e => e.SecretName).Distinct().ToList();
-            var tagMap = new Dictionary<string, List<string>>();
-            if (names.Count > 0)
-            {
-                IQueryable<ObjectMetadata> tagQuery = this.dbContext.Objects
-                    .Where(o => names.Contains(o.ObjectName));
-
-                foreach (var rt in requiredTags)
-                {
-                    var tag = rt; // local capture so closure binds correctly
-                    tagQuery = tagQuery.Where(o => o.Tags.Contains(tag));
-                }
-
-                var tagPairs = await tagQuery
-                    .Select(o => new { o.ObjectName, o.Tags })
-                    .ToListAsync();
-
-                foreach (var pair in tagPairs)
-                {
-                    tagMap[pair.ObjectName] = pair.Tags?.ToList() ?? new List<string>();
-                }
-            }
+            var tagMap = await this.LoadTagMapAsync(names, requiredTags);
 
             if (requiredTags.Count > 0)
             {
@@ -201,8 +244,48 @@ namespace SafeExchange.Core.Functions
                     Status = "ok",
                     Result = dtos
                 });
+        }, nameof(HandleListSecretMetaV3), log);
 
-        }, nameof(HandleListSecretMeta), log);
+        private static (bool ok, IReadOnlyList<string> requiredTags, string? error) TryGetRequiredTags(HttpRequestData request)
+        {
+            var rawTags = Array.Empty<string>();
+            var query = request.Url?.Query;
+            if (!string.IsNullOrEmpty(query))
+            {
+                rawTags = System.Web.HttpUtility.ParseQueryString(query).GetValues("tag") ?? Array.Empty<string>();
+            }
+
+            return TagValidator.TryNormalizeList(rawTags);
+        }
+
+        private async Task<Dictionary<string, List<string>>> LoadTagMapAsync(List<string> names, IReadOnlyList<string> requiredTags)
+        {
+            var tagMap = new Dictionary<string, List<string>>();
+            if (names.Count == 0)
+            {
+                return tagMap;
+            }
+
+            IQueryable<ObjectMetadata> tagQuery = this.dbContext.Objects
+                .Where(o => names.Contains(o.ObjectName));
+
+            foreach (var rt in requiredTags)
+            {
+                var tag = rt; // local capture so closure binds correctly
+                tagQuery = tagQuery.Where(o => o.Tags.Contains(tag));
+            }
+
+            var tagPairs = await tagQuery
+                .Select(o => new { o.ObjectName, o.Tags })
+                .ToListAsync();
+
+            foreach (var pair in tagPairs)
+            {
+                tagMap[pair.ObjectName] = pair.Tags?.ToList() ?? new List<string>();
+            }
+
+            return tagMap;
+        }
 
         private async Task<HttpResponseData> HandleSecretMetaCreation(HttpRequestData request, string secretId, SubjectType subjectType, string subjectId, ILogger log)
             => await ActionResults.TryCatchAsync(request, async () =>

--- a/SafeExchange.Core/Middleware/ApiVersionTelemetryMiddleware.cs
+++ b/SafeExchange.Core/Middleware/ApiVersionTelemetryMiddleware.cs
@@ -1,0 +1,98 @@
+/// <summary>
+/// ApiVersionTelemetryMiddleware
+/// </summary>
+
+namespace SafeExchange.Core.Middleware
+{
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.Azure.Functions.Worker;
+    using Microsoft.Azure.Functions.Worker.Middleware;
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Records which API version each request targeted, so the operator can see how much
+    /// traffic still hits v2 versus v3 and decide when v2 can be retired. The version comes from
+    /// the <c>{apiVersion}</c> route segment. Emits one structured trace per request and stamps a
+    /// <c>saex.apiVersion</c> custom dimension on every telemetry item of the invocation (via
+    /// <see cref="ApiVersionTelemetryInitializer"/>), mirroring the session-correlation approach.
+    /// No-ops for invocations without an <c>apiVersion</c> route value.
+    /// </summary>
+    public class ApiVersionTelemetryMiddleware : IFunctionsWorkerMiddleware
+    {
+        public const string RouteValueName = "apiVersion";
+
+        public const string PropertyName = "saex.apiVersion";
+
+        private static readonly AsyncLocal<string?> currentApiVersion = new();
+
+        private readonly ILogger<ApiVersionTelemetryMiddleware> log;
+
+        public ApiVersionTelemetryMiddleware(ILogger<ApiVersionTelemetryMiddleware> log)
+        {
+            this.log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        internal static string? Current => currentApiVersion.Value;
+
+        public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+        {
+            var apiVersion = TryReadApiVersion(context);
+            if (apiVersion is null)
+            {
+                await next(context).ConfigureAwait(false);
+                return;
+            }
+
+            var previous = currentApiVersion.Value;
+            currentApiVersion.Value = apiVersion;
+            try
+            {
+                this.log.LogInformation("saex api version {ApiVersion} {FunctionName}", apiVersion, context.FunctionDefinition.Name);
+                await next(context).ConfigureAwait(false);
+            }
+            finally
+            {
+                currentApiVersion.Value = previous;
+            }
+        }
+
+        private static string? TryReadApiVersion(FunctionContext context)
+        {
+            if (!context.BindingContext.BindingData.TryGetValue(RouteValueName, out var raw))
+            {
+                return null;
+            }
+
+            var value = raw?.ToString()?.Trim('"');
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+
+    /// <summary>
+    /// Stamps the current request's API version onto every emitted telemetry item, so requests,
+    /// traces and dependencies can be aggregated by <c>saex.apiVersion</c>. No-ops when the
+    /// AsyncLocal is empty (non-HTTP invocations or routes without an apiVersion segment).
+    /// </summary>
+    public class ApiVersionTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            var apiVersion = ApiVersionTelemetryMiddleware.Current;
+            if (string.IsNullOrEmpty(apiVersion))
+            {
+                return;
+            }
+
+            if (telemetry is ISupportProperties supportsProperties
+                && !supportsProperties.Properties.ContainsKey(ApiVersionTelemetryMiddleware.PropertyName))
+            {
+                supportsProperties.Properties[ApiVersionTelemetryMiddleware.PropertyName] = apiVersion;
+            }
+        }
+    }
+}

--- a/SafeExchange.Core/SafeExchangeStartup.cs
+++ b/SafeExchange.Core/SafeExchangeStartup.cs
@@ -59,6 +59,9 @@ namespace SafeExchange.Core
             // but before any handler logs so downstream ILogger scopes
             // inherit the x-saex-session-id correlation.
             builder.UseWhen<SessionCorrelationMiddleware>(IsHttpTrigger);
+
+            // Records the {apiVersion} route segment so v2-vs-v3 traffic can be measured.
+            builder.UseWhen<ApiVersionTelemetryMiddleware>(IsHttpTrigger);
         }
 
         // The categories below are emitted inside the isolated worker process —
@@ -218,6 +221,7 @@ namespace SafeExchange.Core
             // in tandem with SessionCorrelationMiddleware (which sets the
             // AsyncLocal for the duration of the request handler).
             services.AddSingleton<ITelemetryInitializer, SessionCorrelationTelemetryInitializer>();
+            services.AddSingleton<ITelemetryInitializer, ApiVersionTelemetryInitializer>();
 
             // Stamps customDimensions.saex.telemetryId — a pseudonymous, weekly-rotating
             // id — on every telemetry item so traces can be correlated per user without

--- a/SafeExchange.Functions/AdminFunctions/SafeAdminApplications.cs
+++ b/SafeExchange.Functions/AdminFunctions/SafeAdminApplications.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions.AdminFunctions
 
     public class SafeAdminApplications
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeApplications safeExchangeApplicationsHandler;
 

--- a/SafeExchange.Functions/AdminFunctions/SafeAdminOperations.cs
+++ b/SafeExchange.Functions/AdminFunctions/SafeAdminOperations.cs
@@ -16,7 +16,7 @@ namespace SafeExchange.Functions
 
     public class SafeAdminOperations
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeAdminOperations adminOperationsHandler;
 

--- a/SafeExchange.Functions/AdminFunctions/SafeAdminWebhookSubscriptionsList.cs
+++ b/SafeExchange.Functions/AdminFunctions/SafeAdminWebhookSubscriptionsList.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions.AdminFunctions
 
     public class SafeAdminWebhookSubscriptionsList
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeWebhookSubscriptionsList safeExchangeWebhookSubscriptionsListHandler;
 

--- a/SafeExchange.Functions/Functions/SafeAccess.cs
+++ b/SafeExchange.Functions/Functions/SafeAccess.cs
@@ -19,7 +19,7 @@ namespace SafeExchange.Functions
 
     public class SafeAccess
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeAccess accessHandler;
 
@@ -46,10 +46,11 @@ namespace SafeExchange.Functions
         public async Task<HttpResponseData> RunSecret(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", "get", "delete", "patch", Route = $"{Version}/access/{{secretId}}")]
             HttpRequestData request,
+            string apiVersion,
             string secretId)
         {
             var principal = request.FunctionContext.GetPrincipal();
-            return await this.accessHandler.Run(request, secretId, principal, this.log);
+            return await this.accessHandler.Run(request, secretId, principal, this.log, enrichedAccessList: apiVersion == "v3");
         }
     }
 }

--- a/SafeExchange.Functions/Functions/SafeAccessGiveUp.cs
+++ b/SafeExchange.Functions/Functions/SafeAccessGiveUp.cs
@@ -19,7 +19,7 @@ namespace SafeExchange.Functions
 
     public class SafeAccessGiveUp
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeAccessGiveUp giveUpHandler;
 

--- a/SafeExchange.Functions/Functions/SafeAccessRequest.cs
+++ b/SafeExchange.Functions/Functions/SafeAccessRequest.cs
@@ -19,7 +19,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeAccessRequest
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeAccessRequest accessRequestHandler;
 

--- a/SafeExchange.Functions/Functions/SafeAdminApplications.cs
+++ b/SafeExchange.Functions/Functions/SafeAdminApplications.cs
@@ -14,7 +14,7 @@ namespace SafeExchange.Functions
 
     public class SafeAdminApplications
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeAdminApplications handler;
         private readonly ILogger log;

--- a/SafeExchange.Functions/Functions/SafeAdminAudit.cs
+++ b/SafeExchange.Functions/Functions/SafeAdminAudit.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions
 
     public class SafeAdminAudit
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeAdminAudit handler;
         private readonly ILogger log;

--- a/SafeExchange.Functions/Functions/SafeAdminSecrets.cs
+++ b/SafeExchange.Functions/Functions/SafeAdminSecrets.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions
 
     public class SafeAdminSecrets
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeAdminSecrets handler;
         private readonly ILogger log;

--- a/SafeExchange.Functions/Functions/SafeAdminUsers.cs
+++ b/SafeExchange.Functions/Functions/SafeAdminUsers.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions
 
     public class SafeAdminUsers
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeAdminUsers handler;
         private readonly ILogger log;

--- a/SafeExchange.Functions/Functions/SafeApplicationSearch.cs
+++ b/SafeExchange.Functions/Functions/SafeApplicationSearch.cs
@@ -15,7 +15,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeApplicationSearch
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeApplicationSearch safeExchangeApplicationSearchHandler;
 

--- a/SafeExchange.Functions/Functions/SafeApplicationsList.cs
+++ b/SafeExchange.Functions/Functions/SafeApplicationsList.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeApplicationsList
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeApplicationsList safeExchangeApplicationsListHandler;
 

--- a/SafeExchange.Functions/Functions/SafeGroupSearch.cs
+++ b/SafeExchange.Functions/Functions/SafeGroupSearch.cs
@@ -16,7 +16,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeGroupSearch
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeGroupSearch safeExchangeGroupSearchHandler;
 

--- a/SafeExchange.Functions/Functions/SafeGroupsList.cs
+++ b/SafeExchange.Functions/Functions/SafeGroupsList.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeGroupsList
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeGroupsList safeExchangeGroupsListHandler;
 

--- a/SafeExchange.Functions/Functions/SafePinnedGroups.cs
+++ b/SafeExchange.Functions/Functions/SafePinnedGroups.cs
@@ -13,7 +13,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafePinnedGroups
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangePinnedGroups safeExchangePinnedGroupsHandler;
 

--- a/SafeExchange.Functions/Functions/SafePinnedSecrets.cs
+++ b/SafeExchange.Functions/Functions/SafePinnedSecrets.cs
@@ -18,7 +18,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafePinnedSecrets
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangePinnedSecrets safeExchangePinnedSecretsHandler;
 

--- a/SafeExchange.Functions/Functions/SafeS2SApps.cs
+++ b/SafeExchange.Functions/Functions/SafeS2SApps.cs
@@ -20,7 +20,7 @@ namespace SafeExchange.Functions
 
     public class SafeS2SApps
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private readonly SafeExchangeS2SApps handler;
         private readonly ILogger log;

--- a/SafeExchange.Functions/Functions/SafeSecret.cs
+++ b/SafeExchange.Functions/Functions/SafeSecret.cs
@@ -19,7 +19,7 @@ namespace SafeExchange.Functions
 
     public class SafeSecret
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeSecretMeta metaHandler;
 
@@ -66,10 +66,12 @@ namespace SafeExchange.Functions
         [Function("SafeExchange-ListSecretMeta")]
         public async Task<HttpResponseData> RunListSecret(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = $"{Version}/secret-list")]
-            HttpRequestData request)
+            HttpRequestData request, string apiVersion)
         {
             var principal = request.FunctionContext.GetPrincipal();
-            return await this.metaHandler.RunList(request, principal, this.log);
+            return apiVersion == "v3"
+                ? await this.metaHandler.RunListV3(request, principal, this.log)
+                : await this.metaHandler.RunList(request, principal, this.log);
         }
 
         [Function("SafeExchange-SecretContentMetaCreate")]

--- a/SafeExchange.Functions/Functions/SafeTelemetryConfig.cs
+++ b/SafeExchange.Functions/Functions/SafeTelemetryConfig.cs
@@ -15,7 +15,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeTelemetryConfig
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeTelemetryConfig safeExchangeTelemetryConfigHandler;
 

--- a/SafeExchange.Functions/Functions/SafeUserSearch.cs
+++ b/SafeExchange.Functions/Functions/SafeUserSearch.cs
@@ -16,7 +16,7 @@ namespace SafeExchange.Functions.Functions
 
     public class SafeUserSearch
     {
-        private const string Version = "v2";
+        private const string Version = "{apiVersion}";
 
         private SafeExchangeUserSearch safeExchangeUserSearchHandler;
 

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -474,7 +474,7 @@ namespace SafeExchange.Tests
             this.SeedGroupPermission(secret, GroupA, PermissionType.Write);
 
             var request = TestFactory.CreateHttpRequestData("get");
-            var response = await this.secretAccess.Run(request, secret, new ClaimsPrincipal(this.memberIdentity), this.logger) as TestHttpResponseData;
+            var response = await this.secretAccess.Run(request, secret, new ClaimsPrincipal(this.memberIdentity), this.logger, enrichedAccessList: true) as TestHttpResponseData;
 
             Assert.That(response, Is.Not.Null);
             Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
@@ -489,6 +489,38 @@ namespace SafeExchange.Tests
             Assert.That(memberRow, Is.Not.Null, "The access list reports each subject's actual permissions.");
             Assert.That(memberRow!.CanRead, Is.True);
             Assert.That(memberRow.CanWrite, Is.False, "The access list keeps the member's actual direct grant, not the effective one.");
+        }
+
+        [Test]
+        public async Task RunList_V2_ExcludesGroupOnlySecret()
+        {
+            const string secret = "v2-grouponly";
+            await this.CreateSecret(this.ownerIdentity, secret);
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedGroupPermission(secret, GroupA, PermissionType.Read | PermissionType.Write);
+
+            var request = TestFactory.CreateHttpRequestData("get");
+            var response = await this.secretMeta.RunList(request, new ClaimsPrincipal(this.memberIdentity), this.logger) as TestHttpResponseData;
+
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = response.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
+            Assert.That(body?.Result?.Any(p => p.ObjectName == secret), Is.False,
+                "v2 secret-list must stay direct-only — no group-only secrets.");
+        }
+
+        [Test]
+        public async Task GetAccessList_V2_ReturnsPlainArray()
+        {
+            const string secret = "v2-access-array";
+            await this.CreateSecret(this.ownerIdentity, secret);
+
+            var request = TestFactory.CreateHttpRequestData("get");
+            var response = await this.secretAccess.Run(request, secret, new ClaimsPrincipal(this.ownerIdentity), this.logger) as TestHttpResponseData;
+
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var body = response.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
+            Assert.That(body?.Result, Is.Not.Null, "v2 access must return a plain array of subject permissions.");
+            Assert.That(body!.Result!.Any(p => p.SubjectId == "owner@test.test" && p.CanWrite), Is.True);
         }
 
         // ---- Helpers -----------------------------------------------------------------------
@@ -566,7 +598,7 @@ namespace SafeExchange.Tests
         private async Task<SecretListItemOutput?> ListSecretAsync(CaseSensitiveClaimsIdentity identity, string secretName)
         {
             var request = TestFactory.CreateHttpRequestData("get");
-            var response = await this.secretMeta.RunList(request, new ClaimsPrincipal(identity), this.logger) as TestHttpResponseData;
+            var response = await this.secretMeta.RunListV3(request, new ClaimsPrincipal(identity), this.logger) as TestHttpResponseData;
 
             Assert.That(response, Is.Not.Null);
             Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));

--- a/SafeExchange.Tests/Tests/SecretAccessTests.cs
+++ b/SafeExchange.Tests/Tests/SecretAccessTests.cs
@@ -245,11 +245,11 @@ namespace SafeExchange.Tests
             Assert.That(okObjectResult, Is.Not.Null);
             Assert.That(okObjectResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okObjectResult?.ReadBodyAsJson<BaseResponseObject<AccessListOutput>>();
+            var responseResult = okObjectResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Status, Is.EqualTo("ok"));
             Assert.That(responseResult?.Error, Is.Null);
 
-            var permissions = responseResult?.Result?.AccessList;
+            var permissions = responseResult?.Result;
             if (permissions == null)
             {
                 throw new AssertionException("Returned permissions are null.");
@@ -289,11 +289,11 @@ namespace SafeExchange.Tests
             Assert.That(okObjectResult, Is.Not.Null);
             Assert.That(okObjectResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okObjectResult?.ReadBodyAsJson<BaseResponseObject<AccessListOutput>>();
+            var responseResult = okObjectResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Status, Is.EqualTo("ok"));
             Assert.That(responseResult?.Error, Is.Null);
 
-            var permissions = responseResult?.Result?.AccessList;
+            var permissions = responseResult?.Result;
             if (permissions == null)
             {
                 throw new AssertionException("Returned permissions are null.");
@@ -532,11 +532,11 @@ namespace SafeExchange.Tests
             Assert.That(okObjectAccessResult, Is.Not.Null);
             Assert.That(okObjectAccessResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okObjectAccessResult?.ReadBodyAsJson<BaseResponseObject<AccessListOutput>>();
+            var responseResult = okObjectAccessResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Status, Is.EqualTo("ok"));
             Assert.That(responseResult?.Error, Is.Null);
 
-            var permissions = responseResult?.Result?.AccessList;
+            var permissions = responseResult?.Result;
             if (permissions == null)
             {
                 throw new AssertionException("Permissions list is null.");
@@ -791,11 +791,11 @@ namespace SafeExchange.Tests
             Assert.That(okObjectAccessResult, Is.Not.Null);
             Assert.That(okObjectAccessResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okObjectAccessResult?.ReadBodyAsJson<BaseResponseObject<AccessListOutput>>();
+            var responseResult = okObjectAccessResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Status, Is.EqualTo("ok"));
             Assert.That(responseResult?.Error, Is.Null);
 
-            var permissions = responseResult?.Result?.AccessList;
+            var permissions = responseResult?.Result;
             if (permissions == null)
             {
                 throw new AssertionException("Permissions list is null.");

--- a/SafeExchange.Tests/Tests/SecretMetaTests.cs
+++ b/SafeExchange.Tests/Tests/SecretMetaTests.cs
@@ -483,7 +483,7 @@ namespace SafeExchange.Tests
             Assert.That(okObjectListResult, Is.Not.Null);
             Assert.That(okObjectListResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var listResponseResult = okObjectListResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var listResponseResult = okObjectListResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(listResponseResult, Is.Not.Null);
             Assert.That(listResponseResult?.Status, Is.EqualTo("ok"));
             Assert.That(listResponseResult?.Error, Is.Null);
@@ -912,7 +912,7 @@ namespace SafeExchange.Tests
             var okResult = listResponse as TestHttpResponseData;
             Assert.That(okResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult, Is.Not.Null);
             Assert.That(responseResult?.Status, Is.EqualTo("ok"));
 
@@ -943,7 +943,7 @@ namespace SafeExchange.Tests
             var okResult = listResponse as TestHttpResponseData;
             Assert.That(okResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Result, Is.Not.Null);
 
             var names = responseResult!.Result!.Select(p => p.ObjectName).ToList();
@@ -976,7 +976,7 @@ namespace SafeExchange.Tests
             var okResult = listResponse as TestHttpResponseData;
             Assert.That(okResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Result, Is.Not.Null);
 
             var names = responseResult!.Result!.Select(p => p.ObjectName).ToList();
@@ -998,7 +998,7 @@ namespace SafeExchange.Tests
             var okResult = listResponse as TestHttpResponseData;
             Assert.That(okResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Result, Is.Not.Null);
             Assert.That(responseResult!.Result!.Any(p => p.ObjectName == ab), Is.True);
         }
@@ -1020,7 +1020,7 @@ namespace SafeExchange.Tests
             var okResult = listResponse as TestHttpResponseData;
             Assert.That(okResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Result, Is.Not.Null);
 
             var names = responseResult!.Result!.Select(p => p.ObjectName).ToList();
@@ -1048,7 +1048,7 @@ namespace SafeExchange.Tests
             var okResult = listResponse as TestHttpResponseData;
             Assert.That(okResult?.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SecretListItemOutput>>>();
+            var responseResult = okResult?.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(responseResult?.Result, Is.Not.Null);
             Assert.That(responseResult!.Result!.Any(p => p.ObjectName == any), Is.True);
         }


### PR DESCRIPTION
Follow-up to #60. The effective-permissions work changed the shape of `GET v2/secret-list` and `GET v2/access/{id}`, which **breaks existing v2 clients**. This introduces a **v3** API version and restores **v2** to its original behavior so old clients keep working.

## What changed
- Routes now carry a `{apiVersion}` segment (`const Version = "{apiVersion}"`), so every endpoint answers on **both v2 and v3** from a single handler. Only the two enhanced reads branch on version.
- **`v2/secret-list`** → restored to direct-only `List<SubjectPermissionsOutput>` (no group-only inclusion, no effective field). **`v3/secret-list`** → `SecretListItemOutput` (actual direct `Can*` + `callerEffectivePermissions`, includes group-shared secrets).
- **`v2/access/{id}` GET** → restored to a plain `List<SubjectPermissionsOutput>` array. **`v3/access/{id}` GET** → `AccessListOutput { accessList, callerEffectivePermissions }`. Grant/revoke (POST/DELETE/PATCH) are unchanged and version-agnostic.
- **Version telemetry**: `ApiVersionTelemetryMiddleware` logs each request's api version and stamps a `saex.apiVersion` custom dimension on all telemetry — so v2-vs-v3 traffic can be charted to decide when v2 can be retired.
- Telemetry scrub (raw user id → pseudonym) is version-agnostic; applies to both.

## Backward compatibility
- v1 routes untouched.
- v2 shapes/behavior byte-for-byte restored; new backward-compat tests assert v2 list excludes group-only secrets and v2 access returns a plain array.

## Tests
Full suite **524 passing** (Cosmos emulator), including the v2/v3 split and backward-compat coverage.

Frontend counterpart: yury-opolev/safeexchange.blazorpwa (points the client at v3).