### PR TITLE
Pinned-secrets list: expose effective permissions (v3)

### DIFF
--- a/SafeExchange.Core/Functions/SafeExchangePinnedSecretsList.cs
+++ b/SafeExchange.Core/Functions/SafeExchangePinnedSecretsList.cs
@@ -11,6 +11,7 @@ namespace SafeExchange.Core.Functions
     using SafeExchange.Core.Middleware;
     using SafeExchange.Core.Model;
     using SafeExchange.Core.Model.Dto.Output;
+    using SafeExchange.Core.Permissions;
     using SafeExchange.Core.Utilities;
     using SafeExchange.Core.Telemetry;
     using System;
@@ -28,18 +29,22 @@ namespace SafeExchange.Core.Functions
 
         private readonly GlobalFilters globalFilters;
 
+        private readonly IPermissionsManager permissionsManager;
+
         public SafeExchangePinnedSecretsList(
             SafeExchangeDbContext dbContext,
             ITokenHelper tokenHelper,
-            GlobalFilters globalFilters)
+            GlobalFilters globalFilters,
+            IPermissionsManager permissionsManager)
         {
             this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
             this.tokenHelper = tokenHelper ?? throw new ArgumentNullException(nameof(tokenHelper));
             this.globalFilters = globalFilters ?? throw new ArgumentNullException(nameof(globalFilters));
+            this.permissionsManager = permissionsManager ?? throw new ArgumentNullException(nameof(permissionsManager));
         }
 
         public async Task<HttpResponseData> RunList(
-            HttpRequestData request, ClaimsPrincipal principal, ILogger log)
+            HttpRequestData request, ClaimsPrincipal principal, ILogger log, bool effective = false)
         {
             var (shouldReturn, filterResponse) = await this.globalFilters.GetFilterResultAsync(request, principal, this.dbContext);
             if (shouldReturn)
@@ -59,7 +64,9 @@ namespace SafeExchange.Core.Functions
             switch (request.Method.ToLower())
             {
                 case "get":
-                    return await this.HandleList(request, userId, subjectType, subjectId, log);
+                    return effective
+                        ? await this.HandleListV3(request, userId, subjectType, subjectId, log)
+                        : await this.HandleList(request, userId, subjectType, subjectId, log);
 
                 default:
                     return await ActionResults.CreateResponseAsync(
@@ -139,5 +146,75 @@ namespace SafeExchange.Core.Functions
                 new BaseResponseObject<List<PinnedSecretOutput>> { Status = "ok", Result = result });
 
         }, nameof(HandleList), log);
+
+        private async Task<HttpResponseData> HandleListV3(
+            HttpRequestData request, string userId,
+            SubjectType subjectType, string subjectId, ILogger log)
+            => await ActionResults.TryCatchAsync(request, async () =>
+        {
+            var pins = await this.dbContext.PinnedSecrets
+                .Where(p => p.UserId.Equals(userId))
+                .ToListAsync();
+
+            if (pins.Count == 0)
+            {
+                return await ActionResults.CreateResponseAsync(
+                    request, HttpStatusCode.OK,
+                    new BaseResponseObject<List<PinnedSecretListItemOutput>>
+                    {
+                        Status = "no_content",
+                        Result = new List<PinnedSecretListItemOutput>()
+                    });
+            }
+
+            pins = pins.OrderByDescending(p => p.CreatedAt).ToList();
+
+            var names = pins.Select(p => p.SecretName).Distinct().ToList();
+
+            var metadataByName = (await this.dbContext.Objects
+                    .Where(o => names.Contains(o.ObjectName))
+                    .ToListAsync())
+                .ToDictionary(o => o.ObjectName, o => o);
+
+            var directByName = (await this.dbContext.Permissions
+                    .Where(p => names.Contains(p.SecretName)
+                             && p.SubjectType.Equals(subjectType)
+                             && p.SubjectId.Equals(subjectId))
+                    .ToListAsync())
+                .ToDictionary(p => p.SecretName, p => p);
+
+            var result = new List<PinnedSecretListItemOutput>(pins.Count);
+            foreach (var pin in pins)
+            {
+                metadataByName.TryGetValue(pin.SecretName, out var meta);
+                directByName.TryGetValue(pin.SecretName, out var direct);
+
+                var effective = await this.permissionsManager.GetEffectivePermissionsAsync(subjectType, subjectId, pin.SecretName);
+                var callerEffective = EffectivePermissionsOutput.FromPermissionType(effective);
+
+                var dto = new PinnedSecretListItemOutput
+                {
+                    SecretName = pin.SecretName,
+                    Exists = meta is not null,
+                    CanRead = direct?.CanRead ?? false,
+                    CanWrite = direct?.CanWrite ?? false,
+                    CanGrantAccess = direct?.CanGrantAccess ?? false,
+                    CanRevokeAccess = direct?.CanRevokeAccess ?? false,
+                    CallerEffectivePermissions = callerEffective,
+                };
+
+                if (dto.Exists && callerEffective.CanRead)
+                {
+                    dto.Tags = meta!.Tags?.ToList() ?? new List<string>();
+                }
+
+                result.Add(dto);
+            }
+
+            return await ActionResults.CreateResponseAsync(
+                request, HttpStatusCode.OK,
+                new BaseResponseObject<List<PinnedSecretListItemOutput>> { Status = "ok", Result = result });
+
+        }, nameof(HandleListV3), log);
     }
 }

--- a/SafeExchange.Core/Model/Dto/Output/PinnedSecretListItemOutput.cs
+++ b/SafeExchange.Core/Model/Dto/Output/PinnedSecretListItemOutput.cs
@@ -1,0 +1,33 @@
+/// <summary>
+/// PinnedSecretListItemOutput
+/// </summary>
+
+namespace SafeExchange.Core.Model.Dto.Output
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// One entry in the caller's pinned-secrets list (v3). The Can* flags are the caller's actual
+    /// direct grant; CallerEffectivePermissions is the effective grant (direct unioned with
+    /// group-derived). The client presents effective permissions so a secret reachable only through
+    /// a group still shows as accessible rather than "no access".
+    /// </summary>
+    public class PinnedSecretListItemOutput
+    {
+        public string SecretName { get; set; }
+
+        public bool Exists { get; set; }
+
+        public bool CanRead { get; set; }
+
+        public bool CanWrite { get; set; }
+
+        public bool CanGrantAccess { get; set; }
+
+        public bool CanRevokeAccess { get; set; }
+
+        public List<string> Tags { get; set; } = new List<string>();
+
+        public EffectivePermissionsOutput CallerEffectivePermissions { get; set; }
+    }
+}

--- a/SafeExchange.Functions/Functions/SafePinnedSecrets.cs
+++ b/SafeExchange.Functions/Functions/SafePinnedSecrets.cs
@@ -37,7 +37,7 @@ namespace SafeExchange.Functions.Functions
             this.safeExchangePinnedSecretsHandler = new SafeExchangePinnedSecrets(
                 dbContext, tokenHelper, globalFilters, permissionsManager, config);
             this.safeExchangePinnedSecretsListHandler = new SafeExchangePinnedSecretsList(
-                dbContext, tokenHelper, globalFilters);
+                dbContext, tokenHelper, globalFilters, permissionsManager);
             this.log = log ?? throw new ArgumentNullException(nameof(log));
         }
 
@@ -54,10 +54,10 @@ namespace SafeExchange.Functions.Functions
         [Function("SafeExchange-PinnedSecretsList")]
         public async Task<HttpResponseData> RunListPinnedSecrets(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = $"{Version}/pinnedsecrets-list")]
-            HttpRequestData request)
+            HttpRequestData request, string apiVersion)
         {
             var principal = request.FunctionContext.GetPrincipal();
-            return await this.safeExchangePinnedSecretsListHandler.RunList(request, principal, this.log);
+            return await this.safeExchangePinnedSecretsListHandler.RunList(request, principal, this.log, effective: apiVersion == "v3");
         }
     }
 }

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -28,6 +28,7 @@ namespace SafeExchange.Tests
     using SafeExchange.Core.Filters;
     using SafeExchange.Core.Functions;
     using SafeExchange.Core.Groups;
+    using SafeExchange.Core.Middleware;
     using SafeExchange.Core.Model;
     using SafeExchange.Core.Model.Dto.Input;
     using SafeExchange.Core.Model.Dto.Output;
@@ -66,6 +67,7 @@ namespace SafeExchange.Tests
 
         private SafeExchangeSecretMeta secretMeta = null!;
         private SafeExchangeAccess secretAccess = null!;
+        private SafeExchangePinnedSecretsList pinnedList = null!;
 
         private CaseSensitiveClaimsIdentity ownerIdentity = null!;
         private CaseSensitiveClaimsIdentity memberIdentity = null!;
@@ -143,6 +145,9 @@ namespace SafeExchange.Tests
                 this.dbContext, this.groupsManager, this.tokenHelper,
                 this.globalFilters, this.purger, this.permissionsManager,
                 new NoOpAuditWriter(), Mock.Of<IOrphanedSecretManager>());
+
+            this.pinnedList = new SafeExchangePinnedSecretsList(
+                this.dbContext, this.tokenHelper, this.globalFilters, this.permissionsManager);
         }
 
         [TearDown]
@@ -154,6 +159,7 @@ namespace SafeExchange.Tests
             this.dbContext.Objects.RemoveRange(this.dbContext.Objects.ToList());
             this.dbContext.Permissions.RemoveRange(this.dbContext.Permissions.ToList());
             this.dbContext.GroupDictionary.RemoveRange(this.dbContext.GroupDictionary.ToList());
+            this.dbContext.PinnedSecrets.RemoveRange(this.dbContext.PinnedSecrets.ToList());
             this.dbContext.SaveChanges();
         }
 
@@ -521,6 +527,32 @@ namespace SafeExchange.Tests
             var body = response.ReadBodyAsJson<BaseResponseObject<List<SubjectPermissionsOutput>>>();
             Assert.That(body?.Result, Is.Not.Null, "v2 access must return a plain array of subject permissions.");
             Assert.That(body!.Result!.Any(p => p.SubjectId == "owner@test.test" && p.CanWrite), Is.True);
+        }
+
+        [Test]
+        public async Task PinnedListV3_GroupOnlyReadableSecret_ShowsEffectiveRead()
+        {
+            const string secret = "pinned-grouponly";
+            const string memberUserId = "member-user-id";
+            await this.CreateSecret(this.ownerIdentity, secret);
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedGroupPermission(secret, GroupA, PermissionType.Read | PermissionType.Write);
+            this.dbContext.PinnedSecrets.Add(new PinnedSecret(memberUserId, secret));
+            this.dbContext.SaveChanges();
+
+            var request = TestFactory.CreateHttpRequestData("get");
+            request.FunctionContext.Items[DefaultAuthenticationMiddleware.InvocationContextUserIdKey] = memberUserId;
+            var response = await this.pinnedList.RunList(request, new ClaimsPrincipal(this.memberIdentity), this.logger, effective: true) as TestHttpResponseData;
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response!.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            var item = response.ReadBodyAsJson<BaseResponseObject<List<PinnedSecretListItemOutput>>>()?.Result?.SingleOrDefault(p => p.SecretName == secret);
+            Assert.That(item, Is.Not.Null, "Group-only readable pinned secret must appear.");
+            Assert.That(item!.CanRead, Is.False, "Actual direct permissions are empty for a group-only secret.");
+            Assert.That(item.CallerEffectivePermissions.CanRead, Is.True, "Group-derived read is reflected in effective permissions.");
+            Assert.That(item.CallerEffectivePermissions.CanWrite, Is.True);
+            Assert.That(item.Exists, Is.True);
         }
 
         // ---- Helpers -----------------------------------------------------------------------

--- a/SafeExchange.Tests/Tests/PinnedSecretsTests.cs
+++ b/SafeExchange.Tests/Tests/PinnedSecretsTests.cs
@@ -144,7 +144,7 @@ namespace SafeExchange.Tests
                 Options.Create(this.pinnedSecretsConfig));
 
             this.pinnedSecretsList = new SafeExchangePinnedSecretsList(
-                this.dbContext, this.tokenHelper, this.globalFilters);
+                this.dbContext, this.tokenHelper, this.globalFilters, this.permissionsManager);
         }
 
         [TearDown]
@@ -658,7 +658,7 @@ namespace SafeExchange.Tests
                 .Returns("00000000-0000-0000-0000-999999999999");
             appTokenHelper.Setup(h => h.GetDisplayName(It.IsAny<ClaimsPrincipal>())).Returns(string.Empty);
 
-            var appList = new SafeExchangePinnedSecretsList(this.dbContext, appTokenHelper.Object, this.globalFilters);
+            var appList = new SafeExchangePinnedSecretsList(this.dbContext, appTokenHelper.Object, this.globalFilters, this.permissionsManager);
 
             var appIdentity = new CaseSensitiveClaimsIdentity(new List<Claim>
             {


### PR DESCRIPTION
Aligns the pinned-secrets list with the secret-list. The v2 handler read only the caller's **direct** permission rows, so a secret pinned but reachable **only via a group** showed as **"⚠ no access / Request access"** on the Home page even though the caller can read it.

## Changes (v3 only; v2 frozen)
- New `PinnedSecretListItemOutput` (v3): actual direct `Can*` + `CallerEffectivePermissions` (direct ∪ group-derived). `v2/pinnedsecrets-list` stays `PinnedSecretOutput` (direct-only).
- `SafeExchangePinnedSecretsList`: inject `IPermissionsManager`; `RunList(effective:)` → `HandleListV3` computes effective per pinned secret via `GetEffectivePermissionsAsync`; tag inclusion uses effective read. The function branches on the `{apiVersion}` route segment.
- Test: `PinnedListV3_GroupOnlyReadableSecret_ShowsEffectiveRead` (InMemory) — actual `CanRead=false`, effective `CanRead/Write=true`.

Frontend counterpart points the Home/pinned UI at the effective permissions (state + text).

Note: `PinnedSecretsTests` are Cosmos-backed; will confirm green against the emulator before merge.