### PR TITLE
Emit request telemetry to App Insights (Host.Results/Aggregator -> Information)

### DIFF
--- a/SafeExchange.Functions/host.json
+++ b/SafeExchange.Functions/host.json
@@ -8,9 +8,9 @@
       "Microsoft.EntityFrameworkCore": "Warning",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.Azure.Functions.Worker": "Warning",
-      "Host.Aggregator": "Warning",
+      "Host.Aggregator": "Information",
       "Host.Function.Console": "Warning",
-      "Host.Results": "Warning",
+      "Host.Results": "Information",
       "SafeExchange.Core": "Information",
       "System.Net.Http.HttpClient": "Warning"
     },


### PR DESCRIPTION
**Symptom:** App Insights shows **Server requests = 0, Failed requests = 0, Server response time = --** despite live traffic, while ordinary traces still appear.

**Cause:** the Functions host emits per-request telemetry under the `Host.Results` category (and aggregated request metrics under `Host.Aggregator`) at **Information** level. `host.json` had both filtered to **Warning**, so request/metric telemetry was dropped at the source (before sampling — `Request` is already in `excludedTypes`).

**Fix:** set `Host.Results` and `Host.Aggregator` to `Information`. Restores request + aggregated-metric visibility (Server requests, Failed requests, Server response time).

Sampling (`maxTelemetryItemsPerSecond: 2`) is left as-is here — broader sampling relaxation belongs to the upcoming App Insights split (dedicated backend resource).