### PR TITLE
Split Application Insights: backend (AAD-only) + browser (public, daily-capped)

### DIFF
--- a/deployment/current/arm/services-parameters-prd.arm.json
+++ b/deployment/current/arm/services-parameters-prd.arm.json
@@ -77,6 +77,9 @@
         "cosmosdb_isolation_mode": {
             "value": "serviceEndpoint"
         },
+        "backend_appinsights_isolation_mode": {
+            "value": "aadOnly"
+        },
         "provision_nat_gateway": {
             "value": false
         }

--- a/deployment/current/arm/services-parameters-test.arm.json
+++ b/deployment/current/arm/services-parameters-test.arm.json
@@ -59,6 +59,9 @@
         "cosmosdb_isolation_mode": {
             "value": "serviceEndpoint"
         },
+        "backend_appinsights_isolation_mode": {
+            "value": "aadOnly"
+        },
         "provision_nat_gateway": {
             "value": false
         }

--- a/deployment/current/arm/services-template.arm.json
+++ b/deployment/current/arm/services-template.arm.json
@@ -103,6 +103,30 @@
                 "description": "Log analytics workspace name."
             }
         },
+        "browser_appinsights_name": {
+            "defaultValue": "[concat(parameters('safeexchange_site_name'), '-client-insights')]",
+            "type": "string",
+            "metadata": {
+                "description": "Application Insights component for browser/client-side telemetry. A separate resource so the public, browser-facing ingestion endpoint is isolated from backend telemetry and can be independently daily-capped."
+            }
+        },
+        "browser_appinsights_workspace_name": {
+            "defaultValue": "[concat(parameters('safeexchange_site_name'), '-client-la-workspace')]",
+            "type": "string",
+            "metadata": {
+                "description": "Dedicated Log Analytics workspace backing the browser Application Insights, hard-capped via workspaceCapping.dailyQuotaGb to bound cost/abuse on the public ingestion endpoint."
+            }
+        },
+        "backend_appinsights_isolation_mode": {
+            "defaultValue": "aadOnly",
+            "type": "string",
+            "allowedValues": [
+                "aadOnly"
+            ],
+            "metadata": {
+                "description": "Network/auth isolation for the BACKEND Application Insights. 'aadOnly' keeps public ingestion but disables local (connection-string) auth so only the Function App managed identity (granted Monitoring Metrics Publisher) can send telemetry — cheap, no private link. A future 'privateLink' value will additionally provision an Azure Monitor Private Link Scope + private endpoint + private DNS and disable public ingestion/query for full network isolation (extra cost); it is intentionally NOT yet an allowed value until those resources are added and validated, so the switch can never leave the backend AI with public access disabled but no private endpoint (which would break telemetry). Application Insights does not support the cheaper service-endpoint/VNet-rule isolation used by storage/Cosmos/Key Vault."
+            }
+        },
         "settings-aadClient-clientId": {
             "type": "string",
             "metadata": {
@@ -352,6 +376,8 @@
         "appinsights_workspace_retention_days": 90,
         "appinsights_workspace_resource_permissions": true,
         "appinsights_workspace_daily_quota_gb": "[json('0.1')]",
+        "browser_appinsights_workspace_daily_quota_gb": "[json('0.023')]",
+        "is_backend_ai_privatelink": "[equals(parameters('backend_appinsights_isolation_mode'), 'privateLink')]",
 
         "subnet_functionapp_name": "snet-functionapp",
         "subnet_functionapp_prefix": "10.0.0.0/24",
@@ -570,12 +596,49 @@
                 "RetentionInDays": 90,
                 "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('appinsights_workspace_name'))]",
                 "IngestionMode": "LogAnalytics",
+                "publicNetworkAccessForIngestion": "[if(variables('is_backend_ai_privatelink'), 'Disabled', 'Enabled')]",
+                "publicNetworkAccessForQuery": "[if(variables('is_backend_ai_privatelink'), 'Disabled', 'Enabled')]",
+                "DisableLocalAuth": true
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('appinsights_workspace_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[parameters('browser_appinsights_workspace_name')]",
+            "location": "[parameters('default_location')]",
+            "properties": {
+                "sku": {
+                    "name": "PerGB2018"
+                },
+                "retentionInDays": "[variables('appinsights_workspace_retention_days')]",
+                "workspaceCapping": {
+                    "dailyQuotaGb": "[variables('browser_appinsights_workspace_daily_quota_gb')]"
+                },
+                "features": {
+                    "enableLogAccessUsingOnlyResourcePermissions": "[variables('appinsights_workspace_resource_permissions')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Insights/components",
+            "apiVersion": "2020-02-02",
+            "name": "[parameters('browser_appinsights_name')]",
+            "location": "[parameters('default_location')]",
+            "kind": "web",
+            "properties": {
+                "Application_Type": "web",
+                "RetentionInDays": 90,
+                "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('browser_appinsights_workspace_name'))]",
+                "IngestionMode": "LogAnalytics",
                 "publicNetworkAccessForIngestion": "Enabled",
                 "publicNetworkAccessForQuery": "Enabled",
                 "DisableLocalAuth": false
             },
             "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('appinsights_workspace_name'))]"
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('browser_appinsights_workspace_name'))]"
             ]
         },
         {
@@ -1517,6 +1580,23 @@
             }
         },
         {
+            "type": "Microsoft.KeyVault/vaults/secrets",
+            "apiVersion": "2023-02-01",
+            "name": "[concat(parameters('safeexchange_kv_name'), '/WebClientTelemetry--ConnectionString')]",
+            "location": "[parameters('default_location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('safeexchange_kv_name'))]",
+                "[resourceId('Microsoft.Insights/components', parameters('browser_appinsights_name'))]"
+            ],
+            "properties": {
+                "attributes": {
+                    "enabled": true
+                },
+                "contentType": "text/plain",
+                "value": "[reference(resourceId('Microsoft.Insights/components', parameters('browser_appinsights_name')), '2020-02-02').ConnectionString]"
+            }
+        },
+        {
             "condition": "[not(empty(parameters('settings-aadClient-clientSecret')))]",
             "type": "Microsoft.KeyVault/vaults/secrets",
             "apiVersion": "2023-02-01",
@@ -2127,6 +2207,10 @@
                         {
                             "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
                             "value": "[reference(resourceId('Microsoft.Insights/components', parameters('safeexchange_appinsights_name')), '2020-02-02').ConnectionString]"
+                        },
+                        {
+                            "name": "APPLICATIONINSIGHTS_AUTHENTICATION_STRING",
+                            "value": "Authorization=AAD"
                         },
                         {
                             "name": "AzureWebJobsStorage__accountname",


### PR DESCRIPTION
Splits telemetry into **two** App Insights resources so the public browser endpoint is isolated from backend telemetry and independently cost-bounded.

## What
- **Browser AI** (`<site>-client-insights`, new): dedicated Log Analytics workspace **hard-capped at 0.023 GB/day**; **public** ingestion + **local auth** (browsers can't do AAD). The PWA fetches its connection string from `v2/telemetry/config` (the `WebClientTelemetry--ConnectionString` KV secret, now ARM-managed and pointed at this resource) — **no client change**.
- **Backend AI** (`<site>-insights`, existing): **AAD-only** ingestion (`DisableLocalAuth: true`) + `APPLICATIONINSIGHTS_AUTHENTICATION_STRING=Authorization=AAD` on the Function App (its system-assigned MI already has *Monitoring Metrics Publisher*).
- **`backend_appinsights_isolation_mode`** switch (`allowedValues: [aadOnly]` for now). AI has no cheap service-endpoint/VNet-rule isolation like storage/Cosmos/KV — only Private Link (AMPLS). `privateLink` is intentionally **not yet selectable** until its AMPLS/PE/DNS chain is added and validated, so the switch can never leave the backend AI public-disabled with no private endpoint.

## Validation
- `deploy.ps1 -WhatIf`: clean (2 creates, backend AI `DisableLocalAuth` flip, KV secret repoint; other "modifies" are what-if `reference()` noise).
- **Deployed + verified on staging**: browser AI + capped (0.023) workspace created; backend AI `DisableLocalAuth: true`; Function App healthy on AAD ingestion.

Follow-up (separate task): implement + validate the `privateLink` (AMPLS) branch and add it to `allowedValues`.