### PR TITLE
chore: SHA-pin CI actions + fix prd deploy resource group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
     name: Build & test (backend)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
 
@@ -82,10 +82,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
 
@@ -93,7 +93,7 @@ jobs:
         run: dotnet publish SafeExchange.Functions -c Release -o publish
 
       - name: Upload backend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: backend-functions-${{ github.run_number }}
           path: publish

--- a/deployment/deploy.ps1
+++ b/deployment/deploy.ps1
@@ -34,7 +34,7 @@
 
 .PARAMETER ResourceGroup
     Target resource group. Defaults to 'safeexchange-staging' for test
-    and 'safeexchange-backend' for prd.
+    and 'safeexchange' for prd.
 
 .PARAMETER WhatIf
     Run `az deployment group what-if` instead of actually deploying.
@@ -129,7 +129,7 @@ if (-not (Test-Path $paramsPath)) {
 # ──────────────────────────────────────────────────────────────────
 if (-not $ResourceGroup) {
     $ResourceGroup = switch ($Environment) {
-        'prd'  { 'safeexchange-backend' }
+        'prd'  { 'safeexchange' }
         'test' { 'safeexchange-staging' }
     }
     Write-Host "Using default resource group for ${Environment}: $ResourceGroup" -ForegroundColor DarkGray


### PR DESCRIPTION
Two small maintenance fixes.

### 1. `fix(deploy)`: correct prd default resource group
`deploy.ps1` defaulted prd's RG to `safeexchange-backend` (the resource *name*), but the prod resources live in RG **`safeexchange`** — RG `safeexchange-backend` doesn't exist. Verified via `az`: prod func app `safeexchange-backend` → `resourceGroup: safeexchange`. Without this, `deploy.ps1 -Environment prd` fails `ResourceGroupNotFound` unless `-ResourceGroup safeexchange` is passed. Doc comment updated too.

### 2. `ci`: pin GitHub Actions to commit SHAs
`actions/checkout`, `actions/setup-dotnet`, `actions/upload-artifact` pinned to full commit SHAs (with `# v4.x` comments) instead of mutable `@v4` tags — a retagged/compromised action can no longer silently alter the build. Fits the repo's OWASP/supply-chain posture.

- checkout → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- setup-dotnet → `67a3573c9a986a3f9c594539f4ab511d57bb3ce9` (v4.3.1)
- upload-artifact → `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2)

No behavior change; CI runs the same as the green runs on main.

https://claude.ai/code/session_01HDbTJs2M17VF7s5C3NrkEK