### PR TITLE
perf: Propositions - 01 backend items (bounded group queries, batched pin permissions, quieter telemetry)

### DIFF
--- a/SafeExchange.Core/Functions/SafeExchangePinnedSecretsList.cs
+++ b/SafeExchange.Core/Functions/SafeExchangePinnedSecretsList.cs
@@ -183,8 +183,6 @@ namespace SafeExchange.Core.Functions
                     .ToListAsync())
                 .ToDictionary(p => p.SecretName, p => p);
 
-            // One batched calculation for all pins (bounded by the pin cap) instead of a
-            // per-pin user + group + permission query cascade.
             var effectiveByName = await this.permissionsManager.GetEffectivePermissionsAsync(subjectType, subjectId, names);
 
             var result = new List<PinnedSecretListItemOutput>(pins.Count);

--- a/SafeExchange.Core/Functions/SafeExchangePinnedSecretsList.cs
+++ b/SafeExchange.Core/Functions/SafeExchangePinnedSecretsList.cs
@@ -183,14 +183,17 @@ namespace SafeExchange.Core.Functions
                     .ToListAsync())
                 .ToDictionary(p => p.SecretName, p => p);
 
+            // One batched calculation for all pins (bounded by the pin cap) instead of a
+            // per-pin user + group + permission query cascade.
+            var effectiveByName = await this.permissionsManager.GetEffectivePermissionsAsync(subjectType, subjectId, names);
+
             var result = new List<PinnedSecretListItemOutput>(pins.Count);
             foreach (var pin in pins)
             {
                 metadataByName.TryGetValue(pin.SecretName, out var meta);
                 directByName.TryGetValue(pin.SecretName, out var direct);
 
-                var effective = await this.permissionsManager.GetEffectivePermissionsAsync(subjectType, subjectId, pin.SecretName);
-                var callerEffective = EffectivePermissionsOutput.FromPermissionType(effective);
+                var callerEffective = EffectivePermissionsOutput.FromPermissionType(effectiveByName[pin.SecretName]);
 
                 var dto = new PinnedSecretListItemOutput
                 {

--- a/SafeExchange.Core/Middleware/ApiVersionTelemetryMiddleware.cs
+++ b/SafeExchange.Core/Middleware/ApiVersionTelemetryMiddleware.cs
@@ -17,9 +17,11 @@ namespace SafeExchange.Core.Middleware
     /// <summary>
     /// Records which API version each request targeted, so the operator can see how much
     /// traffic still hits v2 versus v3 and decide when v2 can be retired. The version comes from
-    /// the <c>{apiVersion}</c> route segment. Emits one structured trace per request and stamps a
-    /// <c>saex.apiVersion</c> custom dimension on every telemetry item of the invocation (via
-    /// <see cref="ApiVersionTelemetryInitializer"/>), mirroring the session-correlation approach.
+    /// the <c>{apiVersion}</c> route segment. Stamps a <c>saex.apiVersion</c> custom dimension on
+    /// every telemetry item of the invocation (via <see cref="ApiVersionTelemetryInitializer"/>),
+    /// mirroring the session-correlation approach — request telemetry alone carries the dimension,
+    /// so the per-request trace is emitted at Debug only (local troubleshooting) to avoid paying
+    /// Application Insights ingestion for a redundant Information trace on every versioned call.
     /// No-ops for invocations without an <c>apiVersion</c> route value.
     /// </summary>
     public class ApiVersionTelemetryMiddleware : IFunctionsWorkerMiddleware
@@ -52,7 +54,7 @@ namespace SafeExchange.Core.Middleware
             currentApiVersion.Value = apiVersion;
             try
             {
-                this.log.LogInformation("saex api version {ApiVersion} {FunctionName}", apiVersion, context.FunctionDefinition.Name);
+                this.log.LogDebug("saex api version {ApiVersion} {FunctionName}", apiVersion, context.FunctionDefinition.Name);
                 await next(context).ConfigureAwait(false);
             }
             finally

--- a/SafeExchange.Core/Middleware/ApiVersionTelemetryMiddleware.cs
+++ b/SafeExchange.Core/Middleware/ApiVersionTelemetryMiddleware.cs
@@ -18,10 +18,8 @@ namespace SafeExchange.Core.Middleware
     /// Records which API version each request targeted, so the operator can see how much
     /// traffic still hits v2 versus v3 and decide when v2 can be retired. The version comes from
     /// the <c>{apiVersion}</c> route segment. Stamps a <c>saex.apiVersion</c> custom dimension on
-    /// every telemetry item of the invocation (via <see cref="ApiVersionTelemetryInitializer"/>),
-    /// mirroring the session-correlation approach — request telemetry alone carries the dimension,
-    /// so the per-request trace is emitted at Debug only (local troubleshooting) to avoid paying
-    /// Application Insights ingestion for a redundant Information trace on every versioned call.
+    /// every telemetry item of the invocation (via <see cref="ApiVersionTelemetryInitializer"/>);
+    /// the per-request trace is Debug-only, since request telemetry already carries the dimension.
     /// No-ops for invocations without an <c>apiVersion</c> route value.
     /// </summary>
     public class ApiVersionTelemetryMiddleware : IFunctionsWorkerMiddleware

--- a/SafeExchange.Core/Permissions/IPermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/IPermissionsManager.cs
@@ -111,6 +111,21 @@ namespace SafeExchange.Core.Permissions
         public Task<PermissionType> GetEffectivePermissionsAsync(SubjectType subjectType, string subjectId, string secretId);
 
         /// <summary>
+        /// Calculates effective permissions for the specified subject on a bounded set of secrets
+        /// in a fixed number of queries: the subject is normalized once, group memberships are
+        /// loaded once, and direct and group permission rows are each fetched with one query over
+        /// the requested secret names. Every requested name is present in the result (with
+        /// <see cref="PermissionType.None"/> when the subject has no access). Intended for small,
+        /// capped sets such as the pinned-secrets list — not for unbounded name collections.
+        /// </summary>
+        /// <param name="subjectType">Specified subject type.</param>
+        /// <param name="subjectId">Specified subject id.</param>
+        /// <param name="secretNames">The bounded set of secret names to calculate permissions for.</param>
+        /// <returns>The effective permission flags per requested secret name.</returns>
+        public Task<IReadOnlyDictionary<string, PermissionType>> GetEffectivePermissionsAsync(
+            SubjectType subjectType, string subjectId, IReadOnlyCollection<string> secretNames);
+
+        /// <summary>
         /// Returns every secret the specified subject can effectively read (via a direct grant or a
         /// grant inherited through group membership), each with its aggregated effective permissions.
         /// One result per secret — overlapping direct and group grants never produce duplicates.

--- a/SafeExchange.Core/Permissions/IPermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/IPermissionsManager.cs
@@ -111,16 +111,17 @@ namespace SafeExchange.Core.Permissions
         public Task<PermissionType> GetEffectivePermissionsAsync(SubjectType subjectType, string subjectId, string secretId);
 
         /// <summary>
-        /// Calculates effective permissions for the specified subject on a bounded set of secrets
+        /// Calculates effective permissions for the specified subject on a small set of secrets
         /// in a fixed number of queries: the subject is normalized once, group memberships are
         /// loaded once, and direct and group permission rows are each fetched with one query over
         /// the requested secret names. Every requested name is present in the result (with
-        /// <see cref="PermissionType.None"/> when the subject has no access). Intended for small,
-        /// capped sets such as the pinned-secrets list — not for unbounded name collections.
+        /// <see cref="PermissionType.None"/> when the subject has no access). Accepts at most
+        /// 10 distinct names per call and throws <see cref="ArgumentOutOfRangeException"/> above
+        /// that, so the queries stay bounded by contract.
         /// </summary>
         /// <param name="subjectType">Specified subject type.</param>
         /// <param name="subjectId">Specified subject id.</param>
-        /// <param name="secretNames">The bounded set of secret names to calculate permissions for.</param>
+        /// <param name="secretNames">The secret names to calculate permissions for (at most 10 distinct).</param>
         /// <returns>The effective permission flags per requested secret name.</returns>
         public Task<IReadOnlyDictionary<string, PermissionType>> GetEffectivePermissionsAsync(
             SubjectType subjectType, string subjectId, IReadOnlyCollection<string> secretNames);

--- a/SafeExchange.Core/Permissions/IPermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/IPermissionsManager.cs
@@ -111,17 +111,15 @@ namespace SafeExchange.Core.Permissions
         public Task<PermissionType> GetEffectivePermissionsAsync(SubjectType subjectType, string subjectId, string secretId);
 
         /// <summary>
-        /// Calculates effective permissions for the specified subject on a small set of secrets
-        /// in a fixed number of queries: the subject is normalized once, group memberships are
-        /// loaded once, and direct and group permission rows are each fetched with one query over
-        /// the requested secret names. Every requested name is present in the result (with
-        /// <see cref="PermissionType.None"/> when the subject has no access). Accepts at most
-        /// 10 distinct names per call and throws <see cref="ArgumentOutOfRangeException"/> above
-        /// that, so the queries stay bounded by contract.
+        /// Calculates effective permissions for the specified subject on a set of secrets:
+        /// the subject is normalized once, group memberships are loaded once, and direct and
+        /// group permission rows are fetched in bounded batches over the requested secret names.
+        /// Every requested name is present in the result (with <see cref="PermissionType.None"/>
+        /// when the subject has no access).
         /// </summary>
         /// <param name="subjectType">Specified subject type.</param>
         /// <param name="subjectId">Specified subject id.</param>
-        /// <param name="secretNames">The secret names to calculate permissions for (at most 10 distinct).</param>
+        /// <param name="secretNames">The secret names to calculate permissions for.</param>
         /// <returns>The effective permission flags per requested secret name.</returns>
         public Task<IReadOnlyDictionary<string, PermissionType>> GetEffectivePermissionsAsync(
             SubjectType subjectType, string subjectId, IReadOnlyCollection<string> secretNames);

--- a/SafeExchange.Core/Permissions/PermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/PermissionsManager.cs
@@ -11,13 +11,14 @@ namespace SafeExchange.Core.Permissions
     using SafeExchange.Core.Model;
     using SafeExchange.Core.Telemetry;
     using System;
+    using System.Diagnostics;
     using System.Threading.Tasks;
 
     public class PermissionsManager : IPermissionsManager
     {
         internal const int GroupIdQueryBatchSize = 40;
 
-        internal const int MaxEffectivePermissionsRequestSize = 10;
+        internal const int SecretNameQueryBatchSize = 40;
 
         private static readonly List<PermissionType> SinglePermissions =
             new()
@@ -427,28 +428,23 @@ namespace SafeExchange.Core.Permissions
                 return effectiveBySecret;
             }
 
-            if (effectiveBySecret.Count > MaxEffectivePermissionsRequestSize)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(secretNames),
-                    effectiveBySecret.Count,
-                    $"At most {MaxEffectivePermissionsRequestSize} distinct secret names per call.");
-            }
-
             var requestedNames = effectiveBySecret.Keys.ToList();
 
-            var directRows = await this.dbContext.Permissions
-                .Where(p => requestedNames.Contains(p.SecretName)
-                    && p.SubjectType.Equals(subjectType)
-                    && p.SubjectId.Equals(subjectId))
-                .Select(p => new { p.SecretName, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
-                .ToListAsync();
-            foreach (var row in directRows)
+            foreach (var nameBatch in BatchBy(requestedNames, SecretNameQueryBatchSize))
             {
-                AccumulatePermission(
-                    effectiveBySecret,
-                    row.SecretName,
-                    ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
+                var directRows = await this.dbContext.Permissions
+                    .Where(p => nameBatch.Contains(p.SecretName)
+                        && p.SubjectType.Equals(subjectType)
+                        && p.SubjectId.Equals(subjectId))
+                    .Select(p => new { p.SecretName, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
+                    .ToListAsync();
+                foreach (var row in directRows)
+                {
+                    AccumulatePermission(
+                        effectiveBySecret,
+                        row.SecretName,
+                        ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
+                }
             }
 
             if (subjectType == SubjectType.User && this.features.UseGroupsAuthorization)
@@ -458,18 +454,21 @@ namespace SafeExchange.Core.Permissions
                 {
                     // Keyed by SecretName (the partition key); membership filtered in memory.
                     var groupIds = existingUser.Groups.Select(g => g.AadGroupId).ToHashSet();
-                    var groupRows = await this.dbContext.Permissions
-                        .Where(p => requestedNames.Contains(p.SecretName) && p.SubjectType.Equals(SubjectType.Group))
-                        .Select(p => new { p.SecretName, p.SubjectId, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
-                        .ToListAsync();
-                    foreach (var row in groupRows)
+                    foreach (var nameBatch in BatchBy(requestedNames, SecretNameQueryBatchSize))
                     {
-                        if (groupIds.Contains(row.SubjectId))
+                        var groupRows = await this.dbContext.Permissions
+                            .Where(p => nameBatch.Contains(p.SecretName) && p.SubjectType.Equals(SubjectType.Group))
+                            .Select(p => new { p.SecretName, p.SubjectId, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
+                            .ToListAsync();
+                        foreach (var row in groupRows)
                         {
-                            AccumulatePermission(
-                                effectiveBySecret,
-                                row.SecretName,
-                                ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
+                            if (groupIds.Contains(row.SubjectId))
+                            {
+                                AccumulatePermission(
+                                    effectiveBySecret,
+                                    row.SecretName,
+                                    ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
+                            }
                         }
                     }
                 }
@@ -506,12 +505,17 @@ namespace SafeExchange.Core.Permissions
                     // with all group grants in the service; bounded SubjectId batches also keep a
                     // caller with thousands of groups from producing one huge IN clause.
                     var groupIds = existingUser.Groups.Select(g => g.AadGroupId).Distinct().ToList();
+                    var stopwatch = Stopwatch.StartNew();
+                    var queryCount = 0;
+                    var matchedGrantCount = 0;
                     foreach (var batch in BatchBy(groupIds, GroupIdQueryBatchSize))
                     {
+                        queryCount++;
                         var groupRows = await this.dbContext.Permissions
                             .Where(p => p.SubjectType.Equals(SubjectType.Group) && batch.Contains(p.SubjectId))
                             .Select(p => new { p.SecretName, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
                             .ToListAsync();
+                        matchedGrantCount += groupRows.Count;
                         foreach (var row in groupRows)
                         {
                             AccumulatePermission(
@@ -520,6 +524,11 @@ namespace SafeExchange.Core.Permissions
                                 ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
                         }
                     }
+
+                    stopwatch.Stop();
+                    this.logger.LogInformation(
+                        "Group-derived permissions resolved (tid {TelemetryId}): {GroupCount} groups, {QueryCount} queries (batch size {BatchSize}), {MatchedGrantCount} grants, {ElapsedMilliseconds} ms.",
+                        TelemetryContext.Current, groupIds.Count, queryCount, GroupIdQueryBatchSize, matchedGrantCount, stopwatch.ElapsedMilliseconds);
                 }
             }
 

--- a/SafeExchange.Core/Permissions/PermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/PermissionsManager.cs
@@ -15,9 +15,7 @@ namespace SafeExchange.Core.Permissions
 
     public class PermissionsManager : IPermissionsManager
     {
-        // Upper bound for the IN clause of a single group-grant query. Chosen as a safe
-        // starting point; tune from measured Cosmos request charge, query size and latency
-        // (see docs in GetReadableSecretsAsync) rather than raising it speculatively.
+        // Upper bound for one group-grant IN clause; tune from measured Cosmos RU charge and latency.
         internal const int GroupPermissionQueryBatchSize = 50;
 
         private static readonly List<PermissionType> SinglePermissions =
@@ -449,9 +447,7 @@ namespace SafeExchange.Core.Permissions
                 var existingUser = await this.dbContext.Users.FirstOrDefaultAsync(u => u.AadUpn.Equals(subjectId));
                 if (existingUser is not null && !existingUser.ConsentRequired && existingUser.Groups is { Count: > 0 })
                 {
-                    // One group-row query keyed by the requested SecretNames (the container's
-                    // partition key), so only the requested secrets' partitions are touched;
-                    // membership is filtered in memory, as in the single-secret path.
+                    // Keyed by SecretName (the partition key); membership filtered in memory.
                     var groupIds = existingUser.Groups.Select(g => g.AadGroupId).ToHashSet();
                     var groupRows = await this.dbContext.Permissions
                         .Where(p => requestedNames.Contains(p.SecretName) && p.SubjectType.Equals(SubjectType.Group))
@@ -497,12 +493,9 @@ namespace SafeExchange.Core.Permissions
                 var existingUser = await this.dbContext.Users.FirstOrDefaultAsync(u => u.AadUpn.Equals(subjectId));
                 if (existingUser is not null && !existingUser.ConsentRequired && existingUser.Groups is { Count: > 0 })
                 {
-                    // Query group grants in bounded SubjectId batches. The Permissions container is
-                    // partitioned by SecretName, so an unfiltered 'SubjectType == Group' query is a
-                    // cross-partition scan whose cost grows with ALL group grants in the service —
-                    // while a single IN clause over the caller's memberships can explode for users
-                    // in thousands of transitive groups. Bounded batches avoid both extremes, and
-                    // only the fields needed for aggregation are selected.
+                    // The container is partitioned by SecretName, so an unfiltered group scan grows
+                    // with all group grants in the service; bounded SubjectId batches also keep a
+                    // caller with thousands of groups from producing one huge IN clause.
                     var groupIds = existingUser.Groups.Select(g => g.AadGroupId).Distinct().ToList();
                     foreach (var batch in BatchBy(groupIds, GroupPermissionQueryBatchSize))
                     {

--- a/SafeExchange.Core/Permissions/PermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/PermissionsManager.cs
@@ -409,6 +409,70 @@ namespace SafeExchange.Core.Permissions
             return effective;
         }
 
+        public async Task<IReadOnlyDictionary<string, PermissionType>> GetEffectivePermissionsAsync(
+            SubjectType subjectType, string subjectId, IReadOnlyCollection<string> secretNames)
+        {
+            if (subjectType == SubjectType.User)
+            {
+                subjectId = Normalize(subjectId);
+            }
+
+            var effectiveBySecret = new Dictionary<string, PermissionType>(StringComparer.Ordinal);
+            foreach (var secretName in secretNames)
+            {
+                effectiveBySecret[secretName] = PermissionType.None;
+            }
+
+            if (effectiveBySecret.Count == 0)
+            {
+                return effectiveBySecret;
+            }
+
+            var requestedNames = effectiveBySecret.Keys.ToList();
+
+            var directRows = await this.dbContext.Permissions
+                .Where(p => requestedNames.Contains(p.SecretName)
+                    && p.SubjectType.Equals(subjectType)
+                    && p.SubjectId.Equals(subjectId))
+                .Select(p => new { p.SecretName, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
+                .ToListAsync();
+            foreach (var row in directRows)
+            {
+                AccumulatePermission(
+                    effectiveBySecret,
+                    row.SecretName,
+                    ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
+            }
+
+            if (subjectType == SubjectType.User && this.features.UseGroupsAuthorization)
+            {
+                var existingUser = await this.dbContext.Users.FirstOrDefaultAsync(u => u.AadUpn.Equals(subjectId));
+                if (existingUser is not null && !existingUser.ConsentRequired && existingUser.Groups is { Count: > 0 })
+                {
+                    // One group-row query keyed by the requested SecretNames (the container's
+                    // partition key), so only the requested secrets' partitions are touched;
+                    // membership is filtered in memory, as in the single-secret path.
+                    var groupIds = existingUser.Groups.Select(g => g.AadGroupId).ToHashSet();
+                    var groupRows = await this.dbContext.Permissions
+                        .Where(p => requestedNames.Contains(p.SecretName) && p.SubjectType.Equals(SubjectType.Group))
+                        .Select(p => new { p.SecretName, p.SubjectId, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
+                        .ToListAsync();
+                    foreach (var row in groupRows)
+                    {
+                        if (groupIds.Contains(row.SubjectId))
+                        {
+                            AccumulatePermission(
+                                effectiveBySecret,
+                                row.SecretName,
+                                ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
+                        }
+                    }
+                }
+            }
+
+            return effectiveBySecret;
+        }
+
         public async Task<IReadOnlyList<EffectiveSecretPermissions>> GetReadableSecretsAsync(SubjectType subjectType, string subjectId)
         {
             if (subjectType == SubjectType.User)

--- a/SafeExchange.Core/Permissions/PermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/PermissionsManager.cs
@@ -15,8 +15,9 @@ namespace SafeExchange.Core.Permissions
 
     public class PermissionsManager : IPermissionsManager
     {
-        // Upper bound for one group-grant IN clause; tune from measured Cosmos RU charge and latency.
-        internal const int GroupPermissionQueryBatchSize = 50;
+        internal const int GroupIdQueryBatchSize = 20;
+
+        internal const int MaxEffectivePermissionsRequestSize = 10;
 
         private static readonly List<PermissionType> SinglePermissions =
             new()
@@ -426,6 +427,14 @@ namespace SafeExchange.Core.Permissions
                 return effectiveBySecret;
             }
 
+            if (effectiveBySecret.Count > MaxEffectivePermissionsRequestSize)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(secretNames),
+                    effectiveBySecret.Count,
+                    $"At most {MaxEffectivePermissionsRequestSize} distinct secret names per call.");
+            }
+
             var requestedNames = effectiveBySecret.Keys.ToList();
 
             var directRows = await this.dbContext.Permissions
@@ -497,7 +506,7 @@ namespace SafeExchange.Core.Permissions
                     // with all group grants in the service; bounded SubjectId batches also keep a
                     // caller with thousands of groups from producing one huge IN clause.
                     var groupIds = existingUser.Groups.Select(g => g.AadGroupId).Distinct().ToList();
-                    foreach (var batch in BatchBy(groupIds, GroupPermissionQueryBatchSize))
+                    foreach (var batch in BatchBy(groupIds, GroupIdQueryBatchSize))
                     {
                         var groupRows = await this.dbContext.Permissions
                             .Where(p => p.SubjectType.Equals(SubjectType.Group) && batch.Contains(p.SubjectId))

--- a/SafeExchange.Core/Permissions/PermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/PermissionsManager.cs
@@ -15,6 +15,11 @@ namespace SafeExchange.Core.Permissions
 
     public class PermissionsManager : IPermissionsManager
     {
+        // Upper bound for the IN clause of a single group-grant query. Chosen as a safe
+        // starting point; tune from measured Cosmos request charge, query size and latency
+        // (see docs in GetReadableSecretsAsync) rather than raising it speculatively.
+        internal const int GroupPermissionQueryBatchSize = 50;
+
         private static readonly List<PermissionType> SinglePermissions =
             new()
             {
@@ -198,25 +203,42 @@ namespace SafeExchange.Core.Permissions
                 return PermissionType.None;
             }
 
+            return ToPermissionType(
+                subjectPermissions.CanRead,
+                subjectPermissions.CanWrite,
+                subjectPermissions.CanGrantAccess,
+                subjectPermissions.CanRevokeAccess);
+        }
+
+        private static PermissionType ToPermissionType(bool canRead, bool canWrite, bool canGrantAccess, bool canRevokeAccess)
+        {
             var permission = PermissionType.None;
-            if (subjectPermissions.CanRead)
+            if (canRead)
             {
                 permission |= PermissionType.Read;
             }
-            if (subjectPermissions.CanWrite)
+            if (canWrite)
             {
                 permission |= PermissionType.Write;
             }
-            if (subjectPermissions.CanGrantAccess)
+            if (canGrantAccess)
             {
                 permission |= PermissionType.GrantAccess;
             }
-            if (subjectPermissions.CanRevokeAccess)
+            if (canRevokeAccess)
             {
                 permission |= PermissionType.RevokeAccess;
             }
 
             return permission;
+        }
+
+        internal static IEnumerable<List<string>> BatchBy(IReadOnlyList<string> values, int batchSize)
+        {
+            for (var offset = 0; offset < values.Count; offset += batchSize)
+            {
+                yield return values.Skip(offset).Take(batchSize).ToList();
+            }
         }
 
         public static bool IsPresentPermission(SubjectPermissions permissionSet, PermissionType permission)
@@ -411,17 +433,25 @@ namespace SafeExchange.Core.Permissions
                 var existingUser = await this.dbContext.Users.FirstOrDefaultAsync(u => u.AadUpn.Equals(subjectId));
                 if (existingUser is not null && !existingUser.ConsentRequired && existingUser.Groups is { Count: > 0 })
                 {
-                    // Match group grants against the caller's (transitive) group memberships in memory
-                    // via a HashSet, so a caller in thousands of groups never becomes a huge IN clause.
-                    var groupIds = existingUser.Groups.Select(g => g.AadGroupId).ToHashSet();
-                    var groupRows = await this.dbContext.Permissions
-                        .Where(p => p.SubjectType.Equals(SubjectType.Group))
-                        .ToListAsync();
-                    foreach (var row in groupRows)
+                    // Query group grants in bounded SubjectId batches. The Permissions container is
+                    // partitioned by SecretName, so an unfiltered 'SubjectType == Group' query is a
+                    // cross-partition scan whose cost grows with ALL group grants in the service —
+                    // while a single IN clause over the caller's memberships can explode for users
+                    // in thousands of transitive groups. Bounded batches avoid both extremes, and
+                    // only the fields needed for aggregation are selected.
+                    var groupIds = existingUser.Groups.Select(g => g.AadGroupId).Distinct().ToList();
+                    foreach (var batch in BatchBy(groupIds, GroupPermissionQueryBatchSize))
                     {
-                        if (groupIds.Contains(row.SubjectId))
+                        var groupRows = await this.dbContext.Permissions
+                            .Where(p => p.SubjectType.Equals(SubjectType.Group) && batch.Contains(p.SubjectId))
+                            .Select(p => new { p.SecretName, p.CanRead, p.CanWrite, p.CanGrantAccess, p.CanRevokeAccess })
+                            .ToListAsync();
+                        foreach (var row in groupRows)
                         {
-                            AccumulatePermission(effectiveBySecret, row.SecretName, ToPermissionType(row));
+                            AccumulatePermission(
+                                effectiveBySecret,
+                                row.SecretName,
+                                ToPermissionType(row.CanRead, row.CanWrite, row.CanGrantAccess, row.CanRevokeAccess));
                         }
                     }
                 }

--- a/SafeExchange.Core/Permissions/PermissionsManager.cs
+++ b/SafeExchange.Core/Permissions/PermissionsManager.cs
@@ -15,7 +15,7 @@ namespace SafeExchange.Core.Permissions
 
     public class PermissionsManager : IPermissionsManager
     {
-        internal const int GroupIdQueryBatchSize = 20;
+        internal const int GroupIdQueryBatchSize = 40;
 
         internal const int MaxEffectivePermissionsRequestSize = 10;
 

--- a/SafeExchange.Tests/Tests/ApiVersionTelemetryMiddlewareTests.cs
+++ b/SafeExchange.Tests/Tests/ApiVersionTelemetryMiddlewareTests.cs
@@ -1,0 +1,137 @@
+/// <summary>
+/// ApiVersionTelemetryMiddlewareTests
+///
+/// Covers the "Propositions - 01" item 3 change: the per-request API-version trace is emitted
+/// at Debug (not Information), because the saex.apiVersion custom dimension already reaches
+/// request telemetry via ApiVersionTelemetryInitializer. Also pins the AsyncLocal contract:
+/// the version is visible to telemetry during the invocation and restored afterwards.
+/// </summary>
+
+namespace SafeExchange.Tests
+{
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.Azure.Functions.Worker;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using NUnit.Framework;
+    using SafeExchange.Core.Middleware;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class ApiVersionTelemetryMiddlewareTests
+    {
+        private RecordingLevelLogger logger = null!;
+        private ApiVersionTelemetryMiddleware middleware = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.logger = new RecordingLevelLogger();
+            this.middleware = new ApiVersionTelemetryMiddleware(this.logger);
+        }
+
+        [Test]
+        public async Task Invoke_VersionedRequest_EmitsTraceAtDebugOnly()
+        {
+            var context = CreateContext(new Dictionary<string, object?> { ["apiVersion"] = "v3" });
+
+            await this.middleware.Invoke(context, _ => Task.CompletedTask);
+
+            var apiVersionRecords = this.logger.Records.FindAll(r => r.Message.Contains("saex api version"));
+            Assert.That(apiVersionRecords, Has.Count.EqualTo(1), "One trace per versioned request.");
+            Assert.That(apiVersionRecords[0].Level, Is.EqualTo(LogLevel.Debug),
+                "The per-request trace must stay below Information so it carries no ingestion cost by default.");
+        }
+
+        [Test]
+        public async Task Invoke_StampsVersionDuringInvocation_AndRestoresAfter()
+        {
+            var context = CreateContext(new Dictionary<string, object?> { ["apiVersion"] = "v2" });
+
+            string? observedDuringNext = null;
+            await this.middleware.Invoke(context, _ =>
+            {
+                observedDuringNext = ApiVersionTelemetryMiddleware.Current;
+                return Task.CompletedTask;
+            });
+
+            Assert.That(observedDuringNext, Is.EqualTo("v2"));
+            Assert.That(ApiVersionTelemetryMiddleware.Current, Is.Null, "The previous AsyncLocal value is restored in finally.");
+        }
+
+        [Test]
+        public async Task Invoke_RestoresVersionEvenWhenNextThrows()
+        {
+            var context = CreateContext(new Dictionary<string, object?> { ["apiVersion"] = "v3" });
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await this.middleware.Invoke(context, _ => throw new InvalidOperationException("boom")));
+
+            Assert.That(ApiVersionTelemetryMiddleware.Current, Is.Null);
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        public async Task Invoke_NoApiVersionRouteValue_EmitsNothingAndLeavesCurrentUnset()
+        {
+            var context = CreateContext(new Dictionary<string, object?>());
+
+            string? observedDuringNext = "sentinel";
+            await this.middleware.Invoke(context, _ =>
+            {
+                observedDuringNext = ApiVersionTelemetryMiddleware.Current;
+                return Task.CompletedTask;
+            });
+
+            Assert.That(observedDuringNext, Is.Null);
+            Assert.That(this.logger.Records, Is.Empty);
+        }
+
+        [Test]
+        public async Task Initializer_StampsDimensionDuringInvocation_ButNotOutside()
+        {
+            var context = CreateContext(new Dictionary<string, object?> { ["apiVersion"] = "v3" });
+            var initializer = new ApiVersionTelemetryInitializer();
+
+            var insideTelemetry = new TraceTelemetry("inside");
+            await this.middleware.Invoke(context, _ =>
+            {
+                initializer.Initialize(insideTelemetry);
+                return Task.CompletedTask;
+            });
+
+            var outsideTelemetry = new TraceTelemetry("outside");
+            initializer.Initialize(outsideTelemetry);
+
+            Assert.That(insideTelemetry.Properties[ApiVersionTelemetryMiddleware.PropertyName], Is.EqualTo("v3"),
+                "Telemetry emitted during the invocation carries the saex.apiVersion dimension.");
+            Assert.That(outsideTelemetry.Properties.ContainsKey(ApiVersionTelemetryMiddleware.PropertyName), Is.False);
+        }
+
+        private static FunctionContext CreateContext(IDictionary<string, object?> bindingData)
+        {
+            var bindingContext = Mock.Of<BindingContext>(b =>
+                b.BindingData == (IReadOnlyDictionary<string, object?>)new Dictionary<string, object?>(bindingData));
+            var definition = Mock.Of<FunctionDefinition>(d => d.Name == "TestFunction");
+
+            var contextMock = new Mock<FunctionContext>();
+            contextMock.SetupGet(c => c.BindingContext).Returns(bindingContext);
+            contextMock.SetupGet(c => c.FunctionDefinition).Returns(definition);
+            return contextMock.Object;
+        }
+
+        private sealed class RecordingLevelLogger : ILogger<ApiVersionTelemetryMiddleware>
+        {
+            public List<(LogLevel Level, string Message)> Records { get; } = new();
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                => this.Records.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -379,6 +379,49 @@ namespace SafeExchange.Tests
             Assert.That(readable.Single(e => e.SecretName == secretB).Effective, Is.EqualTo(PermissionType.Read | PermissionType.Write));
         }
 
+        [Test]
+        public async Task GetReadableSecrets_ManyGroups_SpansMultipleBatches_AndStaysCorrect()
+        {
+            const string firstBatchSecret = "read-batch-first";
+            const string lastBatchSecret = "read-batch-last";
+            const string unrelatedSecret = "read-batch-unrelated";
+
+            // Enough memberships for three bounded group-grant queries, so the batching loop
+            // (not just its first iteration) is exercised.
+            var groupCount = (PermissionsManager.GroupPermissionQueryBatchSize * 2) + 7;
+            var groupIds = Enumerable.Range(0, groupCount).Select(i => $"batch-group-{i:D4}").ToArray();
+            this.SeedMember(consentRequired: false, groupIds);
+
+            this.SeedGroupPermission(firstBatchSecret, groupIds[0], PermissionType.Read);
+            this.SeedGroupPermission(lastBatchSecret, groupIds[^1], PermissionType.Read | PermissionType.Write);
+            this.SeedGroupPermission(unrelatedSecret, "not-a-member-group", PermissionType.Read);
+
+            var readable = await this.permissionsManager.GetReadableSecretsAsync(SubjectType.User, MemberUpn);
+
+            Assert.That(readable.Single(e => e.SecretName == firstBatchSecret).Effective, Is.EqualTo(PermissionType.Read));
+            Assert.That(readable.Single(e => e.SecretName == lastBatchSecret).Effective, Is.EqualTo(PermissionType.Read | PermissionType.Write));
+            Assert.That(readable.Any(e => e.SecretName == unrelatedSecret), Is.False,
+                "Grants to groups the caller is not a member of must never surface.");
+        }
+
+        [Test]
+        public void BatchBy_SplitsIntoBoundedBatchesPreservingOrder()
+        {
+            var values = Enumerable.Range(0, 101).Select(i => $"id-{i}").ToList();
+
+            var batches = PermissionsManager.BatchBy(values, 50).ToList();
+
+            Assert.That(batches.Count, Is.EqualTo(3));
+            Assert.That(batches.All(b => b.Count <= 50), Is.True, "No batch may exceed the bounded IN-clause size.");
+            Assert.That(batches.SelectMany(b => b), Is.EqualTo(values));
+        }
+
+        [Test]
+        public void BatchBy_EmptyInput_YieldsNoBatches()
+        {
+            Assert.That(PermissionsManager.BatchBy(new List<string>(), 50), Is.Empty);
+        }
+
         // ---- Telemetry scrubbing -----------------------------------------------------------
 
         [Test]

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -453,8 +453,6 @@ namespace SafeExchange.Tests
             const string lastBatchSecret = "read-batch-last";
             const string unrelatedSecret = "read-batch-unrelated";
 
-            // Enough memberships for three bounded group-grant queries, so the batching loop
-            // (not just its first iteration) is exercised.
             var groupCount = (PermissionsManager.GroupPermissionQueryBatchSize * 2) + 7;
             var groupIds = Enumerable.Range(0, groupCount).Select(i => $"batch-group-{i:D4}").ToArray();
             this.SeedMember(consentRequired: false, groupIds);

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -332,6 +332,48 @@ namespace SafeExchange.Tests
         }
 
         [Test]
+        public async Task GetEffectivePermissionsBatch_GroupsFeatureDisabled_ReturnsDirectOnly()
+        {
+            const string secret = "namebatch-groups-off";
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedDirectUserPermission(secret, MemberUpn, PermissionType.Read);
+            this.SeedGroupPermission(secret, GroupA, PermissionType.Write);
+
+            var noGroupsManager = this.CreatePermissionsManager(useGroupsAuthorization: false);
+            var batched = await noGroupsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, new[] { secret });
+
+            Assert.That(batched[secret], Is.EqualTo(PermissionType.Read));
+        }
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_UserWithoutGroups_ReturnsDirectOnly()
+        {
+            const string secret = "namebatch-no-groups";
+            this.SeedMember(consentRequired: false); // no group memberships
+            this.SeedDirectUserPermission(secret, MemberUpn, PermissionType.Read);
+            this.SeedGroupPermission(secret, GroupA, PermissionType.Write);
+
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, new[] { secret });
+
+            Assert.That(batched[secret], Is.EqualTo(PermissionType.Read));
+        }
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_SubjectIdNormalized()
+        {
+            const string secret = "namebatch-normalize";
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedDirectUserPermission(secret, MemberUpn, PermissionType.Read);
+            this.SeedGroupPermission(secret, GroupA, PermissionType.Write);
+
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(
+                SubjectType.User, $"  {MemberUpn.ToUpperInvariant()}  ", new[] { secret });
+
+            Assert.That(batched[secret], Is.EqualTo(PermissionType.Read | PermissionType.Write),
+                "Direct and group-derived grants must resolve for a differently-cased, padded subject id.");
+        }
+
+        [Test]
         public async Task GetEffectivePermissionsBatch_EmptySet_ReturnsEmpty()
         {
             var batched = await this.permissionsManager.GetEffectivePermissionsAsync(
@@ -509,6 +551,37 @@ namespace SafeExchange.Tests
             Assert.That(trace, Does.Contain($"{groupCount} groups").And.Contain("3 queries").And.Contain("2 grants"));
             Assert.That(trace, Does.Not.Contain(MemberUpn).IgnoreCase,
                 "The trace must not carry the caller's raw user identifier.");
+        }
+
+        [Test]
+        public async Task GetReadableSecrets_GroupsFeatureDisabled_ExcludesGroupSecrets()
+        {
+            const string groupSecret = "read-flag-off-group";
+            const string directSecret = "read-flag-off-direct";
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedGroupPermission(groupSecret, GroupA, PermissionType.Read);
+            this.SeedDirectUserPermission(directSecret, MemberUpn, PermissionType.Read);
+
+            var noGroupsManager = this.CreatePermissionsManager(useGroupsAuthorization: false);
+            var readable = await noGroupsManager.GetReadableSecretsAsync(SubjectType.User, MemberUpn);
+
+            Assert.That(readable.Any(e => e.SecretName == directSecret), Is.True);
+            Assert.That(readable.Any(e => e.SecretName == groupSecret), Is.False);
+        }
+
+        [Test]
+        public async Task GetReadableSecrets_UnknownUser_ReturnsDirectOnly()
+        {
+            const string groupSecret = "read-no-user-group";
+            const string directSecret = "read-no-user-direct";
+            // No Users row seeded for the caller at all.
+            this.SeedGroupPermission(groupSecret, GroupA, PermissionType.Read);
+            this.SeedDirectUserPermission(directSecret, MemberUpn, PermissionType.Read);
+
+            var readable = await this.permissionsManager.GetReadableSecretsAsync(SubjectType.User, MemberUpn);
+
+            Assert.That(readable.Any(e => e.SecretName == directSecret), Is.True);
+            Assert.That(readable.Any(e => e.SecretName == groupSecret), Is.False);
         }
 
         [Test]

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -296,6 +296,31 @@ namespace SafeExchange.Tests
         }
 
         [Test]
+        public void GetEffectivePermissionsBatch_OverRequestCap_Throws()
+        {
+            var names = Enumerable.Range(0, PermissionsManager.MaxEffectivePermissionsRequestSize + 1)
+                .Select(i => $"cap-{i}")
+                .ToArray();
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, names));
+        }
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_DuplicateNamesWithinCap_Allowed()
+        {
+            const string secret = "cap-dupes";
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedDirectUserPermission(secret, MemberUpn, PermissionType.Read);
+
+            var names = Enumerable.Repeat(secret, PermissionsManager.MaxEffectivePermissionsRequestSize + 5).ToArray();
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, names);
+
+            Assert.That(batched.Count, Is.EqualTo(1));
+            Assert.That(batched[secret], Is.EqualTo(PermissionType.Read));
+        }
+
+        [Test]
         public async Task GetEffectivePermissionsBatch_EmptySet_ReturnsEmpty()
         {
             var batched = await this.permissionsManager.GetEffectivePermissionsAsync(
@@ -453,7 +478,7 @@ namespace SafeExchange.Tests
             const string lastBatchSecret = "read-batch-last";
             const string unrelatedSecret = "read-batch-unrelated";
 
-            var groupCount = (PermissionsManager.GroupPermissionQueryBatchSize * 2) + 7;
+            var groupCount = (PermissionsManager.GroupIdQueryBatchSize * 2) + 7;
             var groupIds = Enumerable.Range(0, groupCount).Select(i => $"batch-group-{i:D4}").ToArray();
             this.SeedMember(consentRequired: false, groupIds);
 

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -296,24 +296,35 @@ namespace SafeExchange.Tests
         }
 
         [Test]
-        public void GetEffectivePermissionsBatch_OverRequestCap_Throws()
+        public async Task GetEffectivePermissionsBatch_ManyNames_SpansMultipleBatches_AndStaysCorrect()
         {
-            var names = Enumerable.Range(0, PermissionsManager.MaxEffectivePermissionsRequestSize + 1)
-                .Select(i => $"cap-{i}")
-                .ToArray();
+            const string directSecret = "namebatch-direct";
+            const string groupSecret = "namebatch-group";
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedDirectUserPermission(directSecret, MemberUpn, PermissionType.Read);
+            this.SeedGroupPermission(groupSecret, GroupA, PermissionType.Read | PermissionType.Write);
 
-            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
-                await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, names));
+            var names = Enumerable.Range(0, PermissionsManager.SecretNameQueryBatchSize + 5)
+                .Select(i => $"namebatch-none-{i:D3}")
+                .Append(directSecret)
+                .Append(groupSecret)
+                .ToArray();
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, names);
+
+            Assert.That(batched.Count, Is.EqualTo(names.Length), "Every requested name must be present in the result.");
+            Assert.That(batched[directSecret], Is.EqualTo(PermissionType.Read));
+            Assert.That(batched[groupSecret], Is.EqualTo(PermissionType.Read | PermissionType.Write));
+            Assert.That(batched.Where(kvp => kvp.Key.StartsWith("namebatch-none-")).All(kvp => kvp.Value == PermissionType.None), Is.True);
         }
 
         [Test]
-        public async Task GetEffectivePermissionsBatch_DuplicateNamesWithinCap_Allowed()
+        public async Task GetEffectivePermissionsBatch_DuplicateNames_Deduplicated()
         {
-            const string secret = "cap-dupes";
+            const string secret = "namebatch-dupes";
             this.SeedMember(consentRequired: false, GroupA);
             this.SeedDirectUserPermission(secret, MemberUpn, PermissionType.Read);
 
-            var names = Enumerable.Repeat(secret, PermissionsManager.MaxEffectivePermissionsRequestSize + 5).ToArray();
+            var names = Enumerable.Repeat(secret, 15).ToArray();
             var batched = await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, names);
 
             Assert.That(batched.Count, Is.EqualTo(1));
@@ -492,6 +503,12 @@ namespace SafeExchange.Tests
             Assert.That(readable.Single(e => e.SecretName == lastBatchSecret).Effective, Is.EqualTo(PermissionType.Read | PermissionType.Write));
             Assert.That(readable.Any(e => e.SecretName == unrelatedSecret), Is.False,
                 "Grants to groups the caller is not a member of must never surface.");
+
+            var trace = this.permissionsLogger.Messages.SingleOrDefault(m => m.Contains("Group-derived permissions resolved"));
+            Assert.That(trace, Is.Not.Null, "Group resolution emits one telemetry trace per call.");
+            Assert.That(trace, Does.Contain($"{groupCount} groups").And.Contain("3 queries").And.Contain("2 grants"));
+            Assert.That(trace, Does.Not.Contain(MemberUpn).IgnoreCase,
+                "The trace must not carry the caller's raw user identifier.");
         }
 
         [Test]

--- a/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
+++ b/SafeExchange.Tests/Tests/EffectivePermissionsTests.cs
@@ -266,6 +266,73 @@ namespace SafeExchange.Tests
             Assert.That(effective, Is.EqualTo(PermissionType.Read));
         }
 
+        // ---- Batched effective permission calculation --------------------------------------
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_MatchesPerSecretResults()
+        {
+            const string directSecret = "batch-eff-direct";
+            const string groupSecret = "batch-eff-group";
+            const string unionSecret = "batch-eff-union";
+            const string noAccessSecret = "batch-eff-none";
+            this.SeedMember(consentRequired: false, GroupA);
+            this.SeedDirectUserPermission(directSecret, MemberUpn, PermissionType.Read | PermissionType.Write);
+            this.SeedGroupPermission(groupSecret, GroupA, PermissionType.Read | PermissionType.GrantAccess);
+            this.SeedDirectUserPermission(unionSecret, MemberUpn, PermissionType.Read);
+            this.SeedGroupPermission(unionSecret, GroupA, PermissionType.Write);
+            this.SeedGroupPermission(noAccessSecret, GroupB, PermissionType.Read); // member is not in GroupB
+
+            var names = new[] { directSecret, groupSecret, unionSecret, noAccessSecret };
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, names);
+
+            Assert.That(batched.Count, Is.EqualTo(names.Length), "Every requested name must be present in the result.");
+            foreach (var name in names)
+            {
+                var single = await this.permissionsManager.GetEffectivePermissionsAsync(SubjectType.User, MemberUpn, name);
+                Assert.That(batched[name], Is.EqualTo(single), $"Batched result for '{name}' must equal the per-secret result.");
+            }
+
+            Assert.That(batched[noAccessSecret], Is.EqualTo(PermissionType.None));
+        }
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_EmptySet_ReturnsEmpty()
+        {
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(
+                SubjectType.User, MemberUpn, Array.Empty<string>());
+
+            Assert.That(batched, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_ConsentRequired_ExcludesGroupDerived()
+        {
+            const string groupSecret = "batch-consent-group";
+            const string directSecret = "batch-consent-direct";
+            this.SeedMember(consentRequired: true, GroupA);
+            this.SeedGroupPermission(groupSecret, GroupA, PermissionType.Read | PermissionType.Write);
+            this.SeedDirectUserPermission(directSecret, MemberUpn, PermissionType.Read);
+
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(
+                SubjectType.User, MemberUpn, new[] { groupSecret, directSecret });
+
+            Assert.That(batched[groupSecret], Is.EqualTo(PermissionType.None));
+            Assert.That(batched[directSecret], Is.EqualTo(PermissionType.Read));
+        }
+
+        [Test]
+        public async Task GetEffectivePermissionsBatch_ApplicationCaller_UsesDirectOnly()
+        {
+            const string secret = "batch-eff-app";
+            this.SeedPermission(secret, SubjectType.Application, ApplicationId, ApplicationId, PermissionType.Read | PermissionType.Write);
+            this.SeedGroupPermission(secret, GroupA, PermissionType.GrantAccess);
+
+            var batched = await this.permissionsManager.GetEffectivePermissionsAsync(
+                SubjectType.Application, ApplicationId, new[] { secret });
+
+            Assert.That(batched[secret], Is.EqualTo(PermissionType.Read | PermissionType.Write));
+        }
+
         // ---- Readable secrets: actual (Direct) vs Effective -------------------------------
 
         [Test]


### PR DESCRIPTION
Implements the three backend items from the "Propositions - 01" improvement backlog (reviewed revision 1bd6796).

## 1. Bound group-permission queries for `GetReadableSecretsAsync` (item 1, Medium)

The v3 secret-list resolved group-derived permissions by materializing **every** `SubjectType == Group` row in the service (a cross-partition scan — the container is partitioned by `SecretName`). Replaced with bounded batched queries over the caller''s group IDs (`GroupIdQueryBatchSize = 40` per `IN` clause), selecting only the fields needed for aggregation. A caller in thousands of transitive groups still never produces one unbounded `IN` expression.

Each resolution also emits one structured Information trace (group count, query count, batch size, matched grants, elapsed ms — pseudonymous tid only) so the real group-count distribution can be read from Application Insights `customDimensions` to tune the batch size on production data.

**Measured** on the vNext Cosmos emulator — 500 unrelated group grants service-wide, caller in 200 groups with 30 matching grants, 10 iterations:

| implementation | avg wall-clock | group rows materialized/call |
|---|---|---|
| old unbounded scan | 34–41 ms | 530 |
| batched, size 20 (10 queries) | 40.4 ms | 30 |
| batched, size 40 (5 queries) | **25.5 ms** | 30 |

At 200 memberships the sequential round-trips dominate: size 20 loses its transfer savings to query count; size 40 is fastest while transferring 17× fewer documents than the scan. An earlier 90-group run showed the same shape. Identical readable-secret sets asserted in every run. Emulator numbers are directional — confirm with the new telemetry on production.

## 2. Batched effective permissions for the pinned-secret list (item 2, Low-Medium)

New set-based `IPermissionsManager.GetEffectivePermissionsAsync(subjectType, subjectId, secretNames)`: normalizes the caller once, loads user + group memberships once, and fetches direct and group rows in bounded name batches (`SecretNameQueryBatchSize = 40`), so any request size stays bounded without a throwing cap — raising the pin limit can never become a runtime failure. Every requested name is present in the result (`None` when no access). `HandleListV3` now maps pins from the returned dictionary with zero per-pin database calls.

## 3. API-version trace lowered to Debug (item 3, Low)

`ApiVersionTelemetryInitializer` already stamps `saex.apiVersion` on all invocation telemetry, so the per-request Information trace was redundant ingestion cost. Lowered to Debug; middleware/initializer behavior otherwise unchanged, pinned by tests (AsyncLocal stamp/restore incl. exception path, no-route no-op, dimension inside vs outside an invocation).

## Verification

Full suite **539/539 green** locally against the vNext-preview Cosmos emulator (same image as CI), plus the benchmarks above.

Item 4 of the backlog (client null hardening) shipped in safeexchange.blazorpwa #51.

https://claude.ai/code/session_018vsxd6pk2k4UFwtKo1oYur